### PR TITLE
[Feat] #47 SendKnockView에 GSTextEditor 적용

### DIFF
--- a/GitSpace/Sources/Views/Knock/SendKnockView.swift
+++ b/GitSpace/Sources/Views/Knock/SendKnockView.swift
@@ -29,16 +29,13 @@ struct SendKnockView: View {
     
     var body: some View {
         VStack {
-            VStack {
-                Button {
-                    
-                } label: {
-                    
-                }
-            } // VStack
-            
             ScrollViewReader { proxy in
                 ScrollView {
+                    
+                    HStack {
+                    }
+                    .id(topID)
+                    
                     // MARK: - User Profice Pic
                     AsyncImage(url: URL(string: "https://avatars.githubusercontent.com/u/64696968?v=4")) { image in
                         image
@@ -134,6 +131,8 @@ struct SendKnockView: View {
                                 
                                 withAnimation(.easeInOut.speed(1.5)) { proxy.scrollTo(bottomID) }
                                 
+                                    .becomeFirstResponder()
+                                
                             } label: {
                                 Text("🚀 Offer")
                                     .font(.subheadline)
@@ -163,7 +162,6 @@ struct SendKnockView: View {
                     /// userName에게 KnockMessage를 보내세요!
                     /// 상대방이 Knock message를 확인하기 전까지 수정할 수 있습니다.
                     /// Knock message는 전송 이후에 삭제하거나 취소할 수 없습니다.
-                    /// You can edit your knock message before receiver reads it, but can’t cancel or delete chat once it is sent.
                     if !chatPurpose.isEmpty {
                         
                         VStack(alignment: .center, spacing: 10) {
@@ -171,12 +169,12 @@ struct SendKnockView: View {
                                 Text("Send your Knock messages to")
                                 Text("\("guguhanogu")!")
                                     .bold()
-                            }
+                            } // VStack
                             
                             VStack(alignment: .center) {
                                 Text("You can edit your Knock message before receiver")
                                 Text("reads it, but can't cancel or delete chat once it is sent.")
-                            }
+                            } // VStack
                             .font(.footnote)
                             .foregroundColor(.gsLightGray1)
                             
@@ -193,7 +191,7 @@ struct SendKnockView: View {
                                     .font(.footnote)
                                     .foregroundColor(.gsLightGray1)
                                     .bold()
-                            }
+                            } // HStack
                             .padding(.leading, -75)
                             
                             VStack {
@@ -210,23 +208,24 @@ struct SendKnockView: View {
                                         
                                     )
                                     .padding(.horizontal, 15)
-                                    
-                            }
+                                
+                            } // VStack
                             
-                        }
-                        .padding(.top, 100)
+                        } // VStack
+                        .padding(.top, 80)
                     }
                     
                     HStack {
-                    }.id(bottomID)
-                        .frame(height: 300)
-                        
+                    }
+                    .id(bottomID)
+                    .frame(height: 320)
                     
                 } // ScrollView
+//                .padding(.bottom, keyboardHandler.keyboardHeight)
                 /// chatPurpose 값이 바뀜에 따라 키보드를 bottomID로 이동시킴
                 .onChange(of: chatPurpose) { _ in
                     withAnimation(.easeInOut.speed(1.5)) { proxy.scrollTo(bottomID) }
-                        }
+                }
                 /// TextEditor 이외의 공간을 터치할 경우,
                 /// 키보드 포커싱을 없앰
                 .onTapGesture {
@@ -266,16 +265,55 @@ struct SendKnockView: View {
                         Button {
                             self.endTextEditing()
                         } label: {
-                            Image(systemName: "keyboard.chevron.compact.down")
+                            Image(systemName: keyboardHandler.keyboardHeight > 0
+                                  ? "keyboard.chevron.compact.down"
+                                  : "")
                                 .foregroundColor(.gsLightGray1)
                         }
                         
                     } // HStack
                     .padding(.horizontal)
                     
-                    TextEditor(text: $knockMessage)
-                        .frame(maxHeight: 50)
-                        .focused($isFocused, equals: .edit)
+                    HStack(spacing: 10) {
+                        
+//                        VStack {
+//                            Spacer()
+                            
+                            Button {
+                                print("이미지 첨부 버튼 탭")
+                            } label: {
+                                Image(systemName: "photo.tv")
+                            }
+//                        } // VStack: 이미지 첨부 버튼
+                        
+//                        VStack {
+//                            Spacer()
+                            
+                            Button {
+                                print("레포지토리 선택 버튼 탭")
+                            } label: {
+                                Image("RepositoryIcon")
+                            }
+//                        } // VStack: 레포지토리 선택 버튼
+                            
+                        
+                        GSTextEditor.CustomTextEditorView(style: .message, text: $knockMessage)
+                        
+//                        VStack {
+//                            Spacer()
+                            
+                            Button {
+                                //sendKnock()
+                            } label: {
+                                Image(systemName: "location")
+                            }
+                            .disabled(knockMessage.isEmpty)
+//                        } // VStakc: 노크 전송 버튼
+                        
+                    } // HStack
+                    .foregroundColor(.primary)
+                    .padding(.horizontal)
+                    .padding(.bottom)
                     
                 } else if chatPurpose == "question" {
                     
@@ -305,25 +343,63 @@ struct SendKnockView: View {
                         Button {
                             self.endTextEditing()
                         } label: {
-                            Image(systemName: "keyboard.chevron.compact.down")
+                            Image(systemName: keyboardHandler.keyboardHeight > 0
+                                  ? "keyboard.chevron.compact.down"
+                                  : "")
                                 .foregroundColor(.gsLightGray1)
                         } // Button
                         
                     } // HStack
                     .padding(.horizontal)
                     
-                    TextEditor(text: $knockMessage)
-                        .frame(maxHeight: 50)
-                        .focused($isFocused, equals: .edit)
+                    HStack(spacing: 10) {
+//                        VStack {
+//                            Spacer()
+                            
+                            Button {
+                                print("이미지 첨부 버튼 탭")
+                            } label: {
+                                Image(systemName: "photo.tv")
+                            }
+//                        } // VStack: 이미지 첨부 버튼
+                        
+//                        VStack {
+//                            Spacer()
+                            
+                            Button {
+                                print("레포지토리 선택 버튼 탭")
+                            } label: {
+                                Image("RepositoryIcon")
+                            }
+//                        } // VStack: 레포지토리 선택 버튼
+                        
+                        GSTextEditor.CustomTextEditorView(style: .message, text: $knockMessage)
+                        
+                        
+//                        VStack {
+//                            Spacer()
+                            
+                            Button {
+                                //sendKnock()
+                            } label: {
+                                Image(systemName: "location")
+                            }
+                            .disabled(knockMessage.isEmpty)
+//                        } // VStack
+                    } // HStack
+                    .foregroundColor(.primary)
+                    .padding(.horizontal)
+                    .padding(.bottom)
+                    
                 } // if - else if
             } // VStack
         } // VStack
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-
+            
             ToolbarItemGroup(placement: .principal) {
                 NavigationLink {
-                        ProfileDetailView()
+                    ProfileDetailView()
                 } label: {
                     HStack(spacing: 5) {
                         AsyncImage(url: URL(string: "https://avatars.githubusercontent.com/u/64696968?v=4")) { image in


### PR DESCRIPTION
## 개요 및 관련 이슈
- SendKnockView에 GSTextEditor 적용합니다.

## 작업 사항
- SendKnockView에 GSTextEditor 적용

## 주요 로직(Optional)
```diff
+ GSTextEditor.CustomTextEditorView(style: .message, text: $knockMessage)
```
