### PR TITLE
[Fix] #196 Appearance > Color Scheme 변경 시 앱이 Crash 나는 현상 수정

### DIFF
--- a/GitSpace/GitSpaceApp.swift
+++ b/GitSpace/GitSpaceApp.swift
@@ -11,26 +11,7 @@ import SwiftUI
 struct GitSpaceApp: App {
     // register app delegate for Firebase setup
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
-    
-    // MARK: - 한호
-    // TODO: - AppStorage 관련된 변수들 다른 곳에 옮기기 by.한호
-    @AppStorage("systemAppearance") private var systemAppearance: Int = AppearanceType.allCases.first!.rawValue
-
-    var selectedAppearance: ColorScheme? {
-        guard let appearance = AppearanceType(rawValue: systemAppearance) else { return nil }
         
-        switch appearance {
-        case .light:
-            return .light
-        case .dark:
-            return .dark
-        default:
-            return nil
-        }
-    }
-    // MARK: -
-    
-    
     var body: some Scene {
 		let tabBarRouter = delegate.tabBarRouter
 		let notificationManager = delegate.pushNotificationManager
@@ -48,7 +29,6 @@ struct GitSpaceApp: App {
                 .environmentObject(GitHubAuthManager())
                 .environmentObject(KnockViewManager())
                 .environmentObject(tabBarRouter)
-                .preferredColorScheme(selectedAppearance)
         }
     }
 }

--- a/GitSpace/InitialView.swift
+++ b/GitSpace/InitialView.swift
@@ -11,12 +11,30 @@ struct InitialView: View {
     @EnvironmentObject var githubAuthManager: GitHubAuthManager
     let tabBarRouter: GSTabBarRouter
     
+    // MARK: - 한호
+    @AppStorage("systemAppearance") private var systemAppearance: Int = AppearanceType.allCases.first!.rawValue
+
+    var selectedAppearance: ColorScheme? {
+        guard let appearance = AppearanceType(rawValue: systemAppearance) else { return nil }
+        
+        switch appearance {
+        case .light:
+            return .light
+        case .dark:
+            return .dark
+        default:
+            return nil
+        }
+    }
+    
     var body: some View {
         switch githubAuthManager.state {
         case .signedIn:
             ContentView(tabBarRouter: tabBarRouter)
+                .preferredColorScheme(selectedAppearance)
         case .signedOut:
             SigninView(githubAuthManager: githubAuthManager, tabBarRouter: tabBarRouter)
+                .preferredColorScheme(selectedAppearance)
         }
     }
 }

--- a/GitSpace/Sources/Views/Profile/ProfileDetailView.swift
+++ b/GitSpace/Sources/Views/Profile/ProfileDetailView.swift
@@ -53,11 +53,11 @@ struct ProfileDetailView: View {
                     GSText.CustomTextView(style: .title3, string: "Knock")
                         .frame(maxWidth: .infinity)
                 }
-                    .sheet(isPresented: $showKnockSheet) {
+                .sheet(isPresented: $showKnockSheet) {
                     SendKnockView()
                 }
             }
-                .padding(.vertical, 20)
+            .padding(.vertical, 20)
 
             Divider()
                 .frame(height: 1)
@@ -66,7 +66,7 @@ struct ProfileDetailView: View {
             Spacer()
 
         }
-            .padding(.horizontal, 20)
+        .padding(.horizontal, 20)
     }
 
 }
@@ -108,15 +108,15 @@ struct ProfileSectionView: View {
                         GSText.CustomTextView(style: .body1, string: "\(GitHubAuthManager.authenticatedUser?.bio ?? "")")
                         Spacer()
                     }
-                        .padding(15)
-                        .font(.callout)
-                        .frame(maxWidth: .infinity)
-                        .multilineTextAlignment(.leading)
-                        .background(Color.gsGray3)
-                        .clipShape(
+                    .padding(15)
+                    .font(.callout)
+                    .frame(maxWidth: .infinity)
+                    .multilineTextAlignment(.leading)
+                    .background(Color.gsGray3)
+                    .clipShape(
                         RoundedRectangle(cornerRadius: 10, style: .continuous)
                     )
-                        .padding(.vertical, 10)
+                    .padding(.vertical, 10)
                 }
 
                 // MARK: - 소속
@@ -143,7 +143,7 @@ struct ProfileSectionView: View {
 
                         GSText.CustomTextView(style: .description2, string: GitHubAuthManager.authenticatedUser?.location ?? "")
                     }
-                        .foregroundColor(Color(.systemGray))
+                    .foregroundColor(Color(.systemGray))
                 }
 
                 // MARK: - 링크 이미지, 블로그 및 기타 링크
@@ -204,7 +204,6 @@ struct ProfileSectionView: View {
                     .overlay(Color.gsGray3)
                     .padding(.vertical, 10)
 
-
                 // MARK: - 유저의 README
                 GSText.CustomTextView(style: .caption2, string: "README.md")
 
@@ -213,7 +212,7 @@ struct ProfileSectionView: View {
                         markdownString
                     }
                 }
-                    .onAppear {
+                .onAppear {
 
                     Task {
 
@@ -221,7 +220,7 @@ struct ProfileSectionView: View {
 
                         let result = await GitHubService().requestRepositoryReadme(owner: userName, repositoryName: userName)
 
-//                    let result = await GitHubService().requestRepositoryInformation(owner: userName, repositoryName: userName)
+                        //                    let result = await GitHubService().requestRepositoryInformation(owner: userName, repositoryName: userName)
 
                         switch result {
 
@@ -241,13 +240,9 @@ struct ProfileSectionView: View {
                             print(error)
 
                         }
-
-
                     }
                 }
-
             }
-
         }
     }
 }


### PR DESCRIPTION
## 개요 및 관련 이슈
- Appearance > Color Scheme 변경 시 앱이 Crash 나는 현상을 수정했습니다.

## 작업 사항
Appearance에서 라이트 / 다크 모드를 바꾸면 유저 세션을 잃는 문제가 있었습니다.

![image](https://user-images.githubusercontent.com/64696968/218895762-48a029f4-196f-49d4-aad8-cfed720d5104.png)

GitSpaceApp.swift 파일에 작성한 ` .preferredColorScheme(selectedAppearance) ` 를 InitialView의 ContentView와 SigninView에 각각 달아주면 문제가 해결됩니다.

다음은 문제 해결을 위해 @dahae0320와 @guguhanogu가 시도한 트러블 슈팅 과정입니다.

### 가설
- Appearance가 바뀌면서 InitialView 자체가 새로 그려진다.
이 때 InitialView의 하위에 있는 SigninView가 새로 그려지면서 세션이 바뀔 것이다.

### 가설을 증명하기 위한 실험
- SigninView에는 ` .preferredColorScheme(selectedAppearance) ` 코드를 적용하지 않고 빌드를 해 보았다.

### 결과
- 다크모드로 변경 후 로그아웃을 하면, SigninView는 다크모드 적용이 되지 않았다.

### 결론
- ` preferredColorScheme `의 ColorScheme 값이 바뀜에 따라 이 값의 영향을 받는 뷰들이 새로 그려지는 것을 확인하였다.
- 그렇기 때문에, InitialView에 ` preferredColorScheme `이 적용되었을 때는 하위의 ContentView와 SigninView가 모두 새로 그려지는 것이다.
- SigninView가 새로 그려지면서 CurrentUser의 세션 정보는 유지되지 않는다.
(사실상 SigninView의 메모리가 할당 해제되었을 때, 세션 정보의 메모리 또한 함께 할당 해제되는 것)


## 주요 로직(Optional)
### 변경 전
```diff
WindowGroup {
            InitialView(tabBarRouter: tabBarRouter)
...
-                .preferredColorScheme(selectedAppearance)
        }
```

### 변경 후
```diff
struct InitialView: View {
    var body: some View {
        switch githubAuthManager.state {
        case .signedIn:
                    ContentView(tabBarRouter: tabBarRouter)
+                        .preferredColorScheme(selectedAppearance)
        case .signedOut:
                    SigninView(githubAuthManager: githubAuthManager, tabBarRouter: tabBarRouter)
+                        .preferredColorScheme(selectedAppearance)
        }
    }
}
```

