### PR TITLE
Fix/#215 AddTagSheetView의 Bug를 수정했습니다.

### DIFF
--- a/GitSpace/Sources/Views/Home/AddTagSheetView.swift
+++ b/GitSpace/Sources/Views/Home/AddTagSheetView.swift
@@ -81,6 +81,9 @@ struct AddTagSheetView: View {
                         HStack {
                             TextField("tag name", text: $tagInput)
                                 .textFieldStyle(.roundedBorder)
+                                .onSubmit {
+                                    addNewTag()
+                                }
                             
                             // 태그 추가 버튼
                             Button {


### PR DESCRIPTION
## 개요 및 관련 이슈
- AddTagSheetView의 Bug 및 기능을 보완했습니다.
- #215 

## 작업 사항
- AddTagSheetView의 NavigationTitle 제목을 "Add Custom Tags"로 수정하였습니다.
   - 기존 제목이었던 "Knock Knock"은 뷰 시나리오가 완성되기 전에 있던 제목으로, 현재는 삭제한 상태입니다.
- 사용자가 커스텀 태그의 이름을 입력하고 추가 버튼(+)을 누르면 TextField가 초기화됩니다.
   - 이제 사용자가 다음 커스텀 태그를 추가할 때 사용자가 직접 TextField의 내용을 삭제하지 않아도 됩니다.
- 사용자가 커스텀 태그의 이름을 입력하고 추가 버튼이 아니라 키보드의 return key를 눌러서 태그가 추가되도록 설정하였습니다.
  - TextField에 submit 수정자 추가

## 주요 작업 코드
#### TextField 초기화
- 추가 버튼(+)의 액션에 addNewTag 메서드를 호출하고 그 다음 줄에 초기화 코드를 넣게 되면 비동기 문제로 빈 스트링이 커스텀 태그 배열에 들어가게 된다.
- 그러므로 addNewTag 메서드 내부의 같은 쓰레드에서 await으로 서버에 Tag를 추가하는 비동기 작업이 끝나고 난 후에 TextField를 초기화했다.
```diff
func addNewTag() {
  if shouldBlankTag && shouldExistTag {
      Task {
          await tagViewModel.registerTag(tagName: trimmedTagInput)
          withAnimation {
              tagViewModel.tags.append( Tag(tagName: trimmedTagInput, repositories: []) )
          }
+         tagInput = ""
      }
  }
}
```

#### TextField의 submit 수정자
- iOS 15부터 추가된 [onSubmit 수정자](https://developer.apple.com/documentation/swiftui/view/onsubmit(of:_:))를 사용하여 키보드의 return key를 눌렀을 때 태그를 추가하는 액션이 수행된다.
```diff
HStack {
  TextField("tag name", text: $tagInput)
      .textFieldStyle(.roundedBorder)
+     .onSubmit {
+         addNewTag()
+     }
  
  // 태그 추가 버튼
  Button {
      // FIXME: Animation이 너무 못생겼음.
      /// 앞에서 추가되면 자연스럽게 밀리는 애니메이션으로 수정하기.
      addNewTag()
  } label: {
      Image(systemName: "plus")
          .font(.title2)
          .foregroundColor(.black)
          .padding(5)
  }
}
.padding(.bottom, 30)
```

