### PR TITLE
[Fix] #269 ContributorListView | 유저의 닉네임이 두 줄 이상일 경우, 뷰가 깨지는 현상을 수정했습니다.

### DIFF
--- a/GitSpace/Sources/Views/Home/ContributorListCell.swift
+++ b/GitSpace/Sources/Views/Home/ContributorListCell.swift
@@ -31,11 +31,14 @@ struct ContributorGitSpaceUserListCell: View {
                         style: .sectionTitle,
                         string: targetUser.login)
                 } // VStack
+                .multilineTextAlignment(.leading)
                 
                 Spacer()
                 
                 Image(systemName: "chevron.right")
                     .foregroundColor(.gsGray2)
+                    .frame(width: 10)
+                    
             } // HStack
         }) // GSCanvas
     } // body
@@ -65,6 +68,7 @@ struct ContributorListCell: View {
                         style: .sectionTitle,
                         string: targetUser.login)
                 } // VStack
+                .multilineTextAlignment(.leading)
                 
                 Spacer()
             } // HStack
@@ -73,8 +77,8 @@ struct ContributorListCell: View {
 }
 
 
-struct ContributorListCell_Previews: PreviewProvider {
+struct ContributorGitSpaceUserListCell_Previews: PreviewProvider {
     static var previews: some View {
-        ContributorListCell(targetUser: GithubUser(id: 123, login: "asdf", name: "asdf", email: "asdf@mnawe.com", avatar_url: "asdf", bio: "asdf", company: "asdf", location: "asdf", blog: "asdf", public_repos: 123, followers: 123, following: 123))
+        ContributorGitSpaceUserListCell(targetUser: GithubUser(id: 123, login: "alexandrethsilva", name: "Alexandre Theodoro da Silva helaksdkfjslekfkfkfkllllllllkkkk", email: "asdf@mnawe.com", avatar_url: "asdf", bio: "asdf", company: "asdf", location: "asdf", blog: "asdf", public_repos: 123, followers: 123, following: 123))
     }
 }


### PR DESCRIPTION
## 개요 및 관련 이슈
**ContributorListView** 
- 유저의 닉네임이 두 줄 이상일 경우, 뷰가 깨지는 현상을 수정했습니다.

## 작업 사항
- @yeseul321: ContributorListCell 내부의 VStack에 `multilineTextAlignmnet(.leading)`을 추가하였습니다.
- @guguhanogu: `>` 버튼의 크기를 줄였습니다.

## 주요 로직(Optional)
```diff
VStack(alignment: .leading) {
    /* 유저네임 */
    GSText.CustomTextView(
        style: .title3,
        string: targetUser.name ?? targetUser.login)
                    
    /* 유저ID */
    GSText.CustomTextView(
        style: .sectionTitle,
        string: targetUser.login)
} // VStack
+  .multilineTextAlignment(.leading)
```
