### PR TITLE
[Fix] Firestore DB UserInfo와 관련된 컬렉션과 필드명을 리터럴 값에서 Utility의 전역 상수로 교체합니다.

### DIFF
--- a/GitSpace/Sources/Router/ContentView.swift
+++ b/GitSpace/Sources/Router/ContentView.swift
@@ -61,7 +61,7 @@ struct ContentView: View {
                 
 				// userInfo 할당
                 Utility.loginUserID = uid
-                let _ = await userStore.requestUser(userID: uid)
+                await userStore.requestUser(userID: uid)
 				
             } else {
                 print("Error-ContentView-requestUser : Authentication의 uid가 존재하지 않습니다.")

--- a/GitSpace/Sources/ViewModels/GitHubAuthManager.swift
+++ b/GitSpace/Sources/ViewModels/GitHubAuthManager.swift
@@ -29,8 +29,9 @@ final class GitHubAuthManager: ObservableObject {
     
     //    var result: GitHubUser? = nil
     
+    private let database = Firestore.firestore()
+    private let const = Constant.FirestorePathConst.self
     var authentification = Auth.auth()
-    let database = Firestore.firestore()
     var provider = OAuthProvider(providerID: "github.com")
     private var githubCredential: OAuthCredential? = nil
     var authenticatedUser: GithubUser?
@@ -139,7 +140,7 @@ final class GitHubAuthManager: ObservableObject {
         if let firebaseAuthUID = authentification.currentUser?.uid {
             // 현재 Auth 로그인 uid로 UserInfo에 접근
             database
-                .collection("UserInfo")
+                .collection(const.COLLECTION_USER_INFO)
                 .document(firebaseAuthUID)
                 .getDocument { result, error in
                     // 결과가 없거나, 유저가 존재하지 않으면 UserInfo에 새롭게 추가
@@ -172,7 +173,7 @@ final class GitHubAuthManager: ObservableObject {
                         if existGithubUser != githubUser {
                             let updatedUserInfo: UserInfo = self.getFBUserWithUpdatedGithubUser(FBUser: existUser, githubUser: githubUser)
                             try self.database
-                                .collection("UserInfo")
+                                .collection(const.COLLECTION_USER_INFO)
                                 .document(existUser.id)
                                 .setData(from: updatedUserInfo)
                         }
@@ -239,7 +240,7 @@ final class GitHubAuthManager: ObservableObject {
     private func addUser(_ user: UserInfo) {
         do {
             try database
-                .collection("UserInfo")
+                .collection(const.COLLECTION_USER_INFO)
                 .document(user.id)
                 .setData(from: user.self)
         } catch {
@@ -274,7 +275,7 @@ final class GitHubAuthManager: ObservableObject {
     // MARK: - Delete User at Firestore
     func deleteCurrentUser() async -> Void {
         do {
-            try await database.collection("UserInfo")
+            try await database.collection(const.COLLECTION_USER_INFO)
                 .document(Auth.auth().currentUser?.uid ?? "")
                 .delete()
         } catch let deleteUserError as NSError {

--- a/GitSpace/Sources/ViewModels/MessageViewModel.swift
+++ b/GitSpace/Sources/ViewModels/MessageViewModel.swift
@@ -15,6 +15,7 @@ import FirebaseFirestore
 
 final class MessageStore: ObservableObject {
     
+    
     @Published var messages: [Message]
     @Published var isMessageAdded: Bool
     @Published var deletedMessage: Message? // 메세지 셀 삭제 시 onChange로 반응하는 대상 메세지
@@ -22,6 +23,7 @@ final class MessageStore: ObservableObject {
     
     private var listener: ListenerRegistration?
     private let db = Firestore.firestore()
+    private let const = Constant.FirestorePathConst.self
     var currentChat: Chat? // 채팅방 입장 시, 현재 입장한 Chat 인스턴스를 할당받음. MessageStore 내부에서 Chat DB에 접근하기 위한 변수
     
     init() {
@@ -36,10 +38,10 @@ extension MessageStore {
     private func getMessageDocuments(_ chatID: String) async -> QuerySnapshot? {
         do {
             let snapshot = try await db
-                .collection("Chat")
+                .collection(const.COLLECTION_CHAT)
                 .document(chatID)
-                .collection("Message")
-                .order(by: "sentDate")
+                .collection(const.COLLECTION_MESSAGE)
+                .order(by: const.FIELD_SENT_DATE)
                 .getDocuments()
             return snapshot
         } catch {
@@ -77,9 +79,9 @@ extension MessageStore {
     func addMessage(_ message: Message, chatID: String) {
         do {
             try db
-                .collection("Chat")
+                .collection(const.COLLECTION_CHAT)
                 .document(chatID)
-                .collection("Message")
+                .collection(const.COLLECTION_MESSAGE)
                 .document(message.id)
                 .setData(from: message.self)
         } catch {
@@ -90,13 +92,13 @@ extension MessageStore {
     func updateMessage(_ message: Message, chatID: String) async {
         do {
             try await db
-                .collection("Chat")
+                .collection(const.COLLECTION_CHAT)
                 .document(chatID)
-                .collection("Message")
+                .collection(const.COLLECTION_MESSAGE)
                 .document(message.id)
                 .updateData(
-                    ["textContent" : message.textContent,
-                     "sentDate" : message.sentDate])
+                    [const.FIELD_TEXT_CONTENT : message.textContent,
+                     const.FIELD_SENT_DATE : message.sentDate])
         } catch {
             print("Error-\(#file)-\(#function) : \(error.localizedDescription)")
         }
@@ -105,9 +107,9 @@ extension MessageStore {
     func removeMessage(_ message: Message, chatID: String) async {
         do {
             try await db
-                .collection("Chat")
+                .collection(const.COLLECTION_CHAT)
                 .document(chatID)
-                .collection("Message")
+                .collection(const.COLLECTION_MESSAGE)
                 .document(message.id)
                 .delete()
         } catch {
@@ -140,9 +142,9 @@ extension MessageStore {
     
     func addListener(chatID: String) {
         listener = db
-            .collection("Chat")
+            .collection(const.COLLECTION_CHAT)
             .document(chatID)
-            .collection("Message")
+            .collection(const.COLLECTION_MESSAGE)
             .addSnapshotListener { snapshot, error in
                 // snapshot이 비어있으면 에러 출력 후 리턴
                 guard let snp = snapshot else {

--- a/GitSpace/Sources/ViewModels/MessageViewModel.swift
+++ b/GitSpace/Sources/ViewModels/MessageViewModel.swift
@@ -35,6 +35,19 @@ final class MessageStore: ObservableObject {
 // MARK: -Extension : Message CRUD 관련 함수를 모아둔 Extension
 extension MessageStore {
     
+    /**
+     Firestore에 요청해서 메세지 컬렉션에서 문서들을 반환 받습니다.
+     
+     - Author: 태영
+     
+     - Since: 23.03.10
+     
+     - parameters:
+        - chatID: Message 문서들을 가지고 있는 Chat의 문서 ID
+        - unreadMessageCount: 사용자가 읽지 않은 해당 채팅방의 메세지 갯수
+     
+     - Returns: Chat 문서 ID 하위에 있는 Message 컬렉션의 문서들
+     */
     private func getMessageDocuments(_ chatID: String, unreadMessageCount: Int) async -> QuerySnapshot? {
         do {
             let snapshot = try await db

--- a/GitSpace/Sources/ViewModels/MessageViewModel.swift
+++ b/GitSpace/Sources/ViewModels/MessageViewModel.swift
@@ -42,6 +42,7 @@ extension MessageStore {
                 .document(chatID)
                 .collection(const.COLLECTION_MESSAGE)
                 .order(by: const.FIELD_SENT_DATE)
+                .limit(toLast: 30 + unreadMessageCount)
                 .getDocuments()
             return snapshot
         } catch {

--- a/GitSpace/Sources/ViewModels/MessageViewModel.swift
+++ b/GitSpace/Sources/ViewModels/MessageViewModel.swift
@@ -35,7 +35,7 @@ final class MessageStore: ObservableObject {
 // MARK: -Extension : Message CRUD 관련 함수를 모아둔 Extension
 extension MessageStore {
     
-    private func getMessageDocuments(_ chatID: String) async -> QuerySnapshot? {
+    private func getMessageDocuments(_ chatID: String, unreadMessageCount: Int) async -> QuerySnapshot? {
         do {
             let snapshot = try await db
                 .collection(const.COLLECTION_CHAT)
@@ -57,9 +57,9 @@ extension MessageStore {
     }
     
     // MARK: Method : 채팅 ID를 받아서 메세지들을 불러오는 함수
-    func fetchMessages(chatID: String) async {
+    func fetchMessages(chatID: String, unreadMessageCount: Int) async {
         
-        let snapshot = await getMessageDocuments(chatID)
+        let snapshot = await getMessageDocuments(chatID, unreadMessageCount: unreadMessageCount)
         var newMessages: [Message] = []
         
         if let snapshot {

--- a/GitSpace/Sources/ViewModels/RepositoryViewModel.swift
+++ b/GitSpace/Sources/ViewModels/RepositoryViewModel.swift
@@ -13,7 +13,8 @@ final class RepositoryViewModel: ObservableObject {
 //    @Published var tags: [Tag] = []
     @Published var repositories: [Repository]?
     @Published var filteredRepositories: [Repository]?
-    let database = Firestore.firestore()
+    private let database = Firestore.firestore()
+    private let const = Constant.FirestorePathConst.self
     
     // MARK: - Request Starred Repositories
     /// 인증된 사용자가 Star로 지정한 Repository의 목록을 요청합니다.
@@ -47,7 +48,7 @@ final class RepositoryViewModel: ObservableObject {
         do {
             var filteredRepositoryList: [String] = []
             for tag in selectedTags {
-                let tagInfo = try await database.collection("UserInfo")
+                let tagInfo = try await database.collection(const.COLLECTION_USER_INFO)
                     .document(Auth.auth().currentUser?.uid ?? "")
                     .collection("Tag")
                     .document(tag.id)

--- a/GitSpace/Sources/ViewModels/TagViewModel.swift
+++ b/GitSpace/Sources/ViewModels/TagViewModel.swift
@@ -14,14 +14,15 @@ import FirebaseFirestoreSwift
 final class TagViewModel: ObservableObject {
     @Published var tags: [Tag] = []
     
-    let database = Firestore.firestore()
+    private let database = Firestore.firestore()
+    private let const = Constant.FirestorePathConst.self
     
     // MARK: Request Custom tags
     /// 사용자가 등록한 모든 사용자 정의 태그를 불러옵니다.
     @MainActor
     func requestTags() async -> Void {
         do {
-            let snapshot = try await database.collection("UserInfo")
+            let snapshot = try await database.collection(const.COLLECTION_USER_INFO)
             // FIXME: 현재 유저 id로 변경
 //                .document("50159740")
                 .document(Auth.auth().currentUser?.uid ?? "")
@@ -44,7 +45,7 @@ final class TagViewModel: ObservableObject {
     func registerTag(tagName: String) async -> Void {
         do {
             let tid = UUID().uuidString
-            try await database.collection("UserInfo")
+            try await database.collection(const.COLLECTION_USER_INFO)
             // FIXME: 현재 유저 id로 변경
 //                .document("50159740")
                 .document(Auth.auth().currentUser?.uid ?? "")
@@ -64,7 +65,7 @@ final class TagViewModel: ObservableObject {
     /// 특정 사용자 태그를 삭제합니다.
     func deleteTag(tag: Tag) async -> Void {
         do {
-            try await database.collection("UserInfo")
+            try await database.collection(const.COLLECTION_USER_INFO)
 //                .document("50159740")
             // FIXME: 현재 유저 id로 변경
                 .document(Auth.auth().currentUser?.uid ?? "")
@@ -113,7 +114,7 @@ final class TagViewModel: ObservableObject {
         do {
             for tag in tags {
                 print(tag)
-                try await database.collection("UserInfo")
+                try await database.collection(const.COLLECTION_USER_INFO)
 //                    .document("50159740")
                 // FIXME: 현재 유저 id로 변경
                     .document(Auth.auth().currentUser?.uid ?? "")

--- a/GitSpace/Sources/ViewModels/UserViewModel.swift
+++ b/GitSpace/Sources/ViewModels/UserViewModel.swift
@@ -19,6 +19,8 @@ final class UserStore: ObservableObject {
     @Published var user: UserInfo?
     @Published var users: [UserInfo]
     private let db = Firestore.firestore()
+    private let const = Constant.FirestorePathConst.self
+    private static let const = Constant.FirestorePathConst.self
     
     init(
 		users: [UserInfo] = [],

--- a/GitSpace/Sources/ViewModels/UserViewModel.swift
+++ b/GitSpace/Sources/ViewModels/UserViewModel.swift
@@ -99,7 +99,7 @@ final class UserStore: ObservableObject {
 		
 		do {
 			// GITHUB ID 필드에 저장된 것과 같은 유저 정보를 가져 오도록 쿼링
-			let query = collection.whereField("githubID", isEqualTo: githubID)
+			let query = collection.whereField(const.FIELD_GITHUB_ID, isEqualTo: githubID)
 			let data = try await query.getDocuments().documents
 			var userInformationList: [UserInfo] = []
 			
@@ -121,7 +121,7 @@ final class UserStore: ObservableObject {
 		do {
 			let document = db.collection(const.COLLECTION_USER_INFO).document(userID)
 			try await document.updateData([
-				"deviceToken": deviceToken
+				const.FIELD_DEVICE_TOKEN: deviceToken
 			])
 		} catch {
 			print("Error-\(#file)-\(#function): USERINFO DEVICETOKEN Update Falied")
@@ -210,7 +210,7 @@ final class UserStore: ObservableObject {
             try await db
                 .collection(const.COLLECTION_USER_INFO)
                 .document(user.id)
-                .updateData(["blockedUserIDs" : newBlockedUserIDs])
+                .updateData([const.FIELD_BLOCKED_USER_IDS : newBlockedUserIDs])
         } catch {
             print("Block/Unblock User Update Error : \(error.localizedDescription)")
         }

--- a/GitSpace/Sources/ViewModels/UserViewModel.swift
+++ b/GitSpace/Sources/ViewModels/UserViewModel.swift
@@ -18,7 +18,7 @@ final class UserStore: ObservableObject {
 	@Published var currentUser: UserInfo?
     @Published var user: UserInfo?
     @Published var users: [UserInfo]
-    let db = Firestore.firestore()
+    private let db = Firestore.firestore()
     
     init(
 		users: [UserInfo] = [],

--- a/GitSpace/Sources/ViewModels/UserViewModel.swift
+++ b/GitSpace/Sources/ViewModels/UserViewModel.swift
@@ -37,7 +37,7 @@ final class UserStore: ObservableObject {
     
     private func getUserDocument(userID: String) async -> DocumentSnapshot? {
         do {
-            let snapshot = try await db.collection("UserInfo").document(userID).getDocument()
+            let snapshot = try await db.collection(const.COLLECTION_USER_INFO).document(userID).getDocument()
             return snapshot
         } catch {
             print("Error-\(#file)-\(#function) : \(error.localizedDescription)")
@@ -61,7 +61,7 @@ final class UserStore: ObservableObject {
     }
     
     static func requestAndReturnUser(userID: String) async -> UserInfo? {
-        let doc = Firestore.firestore().collection("UserInfo").document(userID)
+        let doc = Firestore.firestore().collection(const.COLLECTION_USER_INFO).document(userID)
         do {
             let userInfo = try await doc.getDocument(as: UserInfo.self)
             return userInfo
@@ -75,7 +75,7 @@ final class UserStore: ObservableObject {
 	/// USERINFO를 가져오기 위해 호출하는 메소드 입니다.
 	/// userID로 가져온 userInfo를 리턴합니다.
 	public func requestUserInfoWithID(userID: String) async -> UserInfo? {
-		let doc = db.collection("UserInfo").document(userID)
+		let doc = db.collection(const.COLLECTION_USER_INFO).document(userID)
 		
 		do {
 			print(userID)
@@ -95,7 +95,7 @@ final class UserStore: ObservableObject {
 	 nil 리턴의 경우, 우리 앱에 해당 유저가 없음을 UX 전달해야 합니다.
 	 */
 	public func requestUserInfoWithGitHubID(githubID: Int) async -> UserInfo? {
-		let collection = db.collection("UserInfo")
+		let collection = db.collection(const.COLLECTION_USER_INFO)
 		
 		do {
 			// GITHUB ID 필드에 저장된 것과 같은 유저 정보를 가져 오도록 쿼링
@@ -119,7 +119,7 @@ final class UserStore: ObservableObject {
 	 */
 	public func updateUserDeviceToken(userID: String, deviceToken: String) async {
 		do {
-			let document = db.collection("UserInfo").document(userID)
+			let document = db.collection(const.COLLECTION_USER_INFO).document(userID)
 			try await document.updateData([
 				"deviceToken": deviceToken
 			])
@@ -131,7 +131,7 @@ final class UserStore: ObservableObject {
     
     private func getUserDocuments() async -> QuerySnapshot? {
         do {
-            let snapshot = try await db.collection("UserInfo").getDocuments()
+            let snapshot = try await db.collection(const.COLLECTION_USER_INFO).getDocuments()
             return snapshot
         } catch {
             print("Get User Document Error : \(error)")
@@ -208,7 +208,7 @@ final class UserStore: ObservableObject {
         do {
             user.blockedUserIDs = newBlockedUserIDs
             try await db
-                .collection("UserInfo")
+                .collection(const.COLLECTION_USER_INFO)
                 .document(user.id)
                 .updateData(["blockedUserIDs" : newBlockedUserIDs])
         } catch {

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -107,12 +107,14 @@ struct ChatRoomView: View {
             }
         }
         .task {
+            // 유저가 읽지 않은 메세지 갯수를 요청해서 할당
+            let unreadMessageCount: Int = await getUnreadCount()
             // 메세지 리스너 실행, 첫 Request가 이루어지기 전이기 때문에 .added에서 메세지를 추가하지 않음
             messageStore.addListener(chatID: chat.id)
             // 해당 채팅방의 메세지를 날짜순으로 정렬해서 Request
-            await messageStore.fetchMessages(chatID: chat.id)
+            await messageStore.fetchMessages(chatID: chat.id, unreadMessageCount: unreadMessageCount)
             // 유저가 읽지 않은 메세지의 시작 인덱스를 계산해서 할당
-            unreadMessageIndex = await messageStore.messages.count - getUnreadCount()
+            unreadMessageIndex = messageStore.messages.count - unreadMessageCount
             // 읽지 않은 메세지 갯수를 0으로 초기화
             await clearUnreadMessageCount()
         }

--- a/GitSpace/Utilities/Constant.swift
+++ b/GitSpace/Utilities/Constant.swift
@@ -41,6 +41,10 @@ public enum Constant {
         static let FIELD_SENT_DATE: String = "sentDate"
         static let FIELD_TEXT_CONTENT: String = "textContent"
         
+        static let COLLECTION_USER_INFO: String = "UserInfo"
+        static let FIELD_GITHUB_ID: String = "githubID"
+        static let FIELD_DEVICE_TOKEN: String = "deviceToken"
+        static let FIELD_BLOCK_USER_IDS: String = "blockUserIDs"
     }
 	
     //MARK: - Text DesignSystem에 들어갈 속성값들

--- a/GitSpace/Utilities/Constant.swift
+++ b/GitSpace/Utilities/Constant.swift
@@ -37,7 +37,8 @@ public enum Constant {
         static let FIELD_LAST_CONTENT_DATE: String = "lastContentDate"
         static let FIELD_LAST_CONTENT: String = "lastContent"
         static let FIELD_UNREAD_MESSAGE_COUNT = "unreadMessageCount"
-        
+        static let FIELD_SENT_DATE = "sentDate"
+        static let FIELD_TEXT_CONTENT = "textContent"
     }
 	
     //MARK: - Text DesignSystem에 들어갈 속성값들

--- a/GitSpace/Utilities/Constant.swift
+++ b/GitSpace/Utilities/Constant.swift
@@ -44,7 +44,7 @@ public enum Constant {
         static let COLLECTION_USER_INFO: String = "UserInfo"
         static let FIELD_GITHUB_ID: String = "githubID"
         static let FIELD_DEVICE_TOKEN: String = "deviceToken"
-        static let FIELD_BLOCK_USER_IDS: String = "blockUserIDs"
+        static let FIELD_BLOCKED_USER_IDS: String = "blockedUserIDs"
     }
 	
     //MARK: - Text DesignSystem에 들어갈 속성값들

--- a/GitSpace/Utilities/Constant.swift
+++ b/GitSpace/Utilities/Constant.swift
@@ -32,11 +32,12 @@ public enum Constant {
     
     enum FirestorePathConst {
         static let COLLECTION_CHAT: String = "Chat"
-        static let COLLECTION_MESSAGE: String = "Message"
         static let FIELD_JOINED_MEMBER_IDS: String = "joinedMemberIDs"
         static let FIELD_LAST_CONTENT_DATE: String = "lastContentDate"
         static let FIELD_LAST_CONTENT: String = "lastContent"
         static let FIELD_UNREAD_MESSAGE_COUNT = "unreadMessageCount"
+        
+        static let COLLECTION_MESSAGE: String = "Message"
         static let FIELD_SENT_DATE = "sentDate"
         static let FIELD_TEXT_CONTENT = "textContent"
     }

--- a/GitSpace/Utilities/Constant.swift
+++ b/GitSpace/Utilities/Constant.swift
@@ -35,11 +35,12 @@ public enum Constant {
         static let FIELD_JOINED_MEMBER_IDS: String = "joinedMemberIDs"
         static let FIELD_LAST_CONTENT_DATE: String = "lastContentDate"
         static let FIELD_LAST_CONTENT: String = "lastContent"
-        static let FIELD_UNREAD_MESSAGE_COUNT = "unreadMessageCount"
+        static let FIELD_UNREAD_MESSAGE_COUNT: String = "unreadMessageCount"
         
         static let COLLECTION_MESSAGE: String = "Message"
-        static let FIELD_SENT_DATE = "sentDate"
-        static let FIELD_TEXT_CONTENT = "textContent"
+        static let FIELD_SENT_DATE: String = "sentDate"
+        static let FIELD_TEXT_CONTENT: String = "textContent"
+        
     }
 	
     //MARK: - Text DesignSystem에 들어갈 속성값들


### PR DESCRIPTION
## 개요 및 관련 이슈
- #277
- closed

## 주요 로직(Optional)
```swift
static let COLLECTION_USER_INFO: String = "UserInfo"
static let FIELD_GITHUB_ID: String = "githubID"
static let FIELD_DEVICE_TOKEN: String = "deviceToken"
static let FIELD_BLOCKED_USER_IDS: String = "blockedUserIDs"

db
.collection(const.COLLECTION_USER_INFO)
.document(user.id)
.updateData([const.FIELD_BLOCKED_USER_IDS : newBlockedUserIDs])
```
