### PR TITLE
#281 sign in view auto login loading yeseul

### DIFF
--- a/GitSpace/InitialView.swift
+++ b/GitSpace/InitialView.swift
@@ -37,6 +37,7 @@ struct InitialView: View {
                     .environmentObject(UserStore(currentUserID: Auth.auth().currentUser?.uid ?? ""))
             case .pending:
                 LoadingProgressView()
+                    .preferredColorScheme(selectedAppearance)
             case .signedOut:
                 SigninView(githubAuthManager: githubAuthManager, tabBarRouter: tabBarRouter)
                     .preferredColorScheme(selectedAppearance)

--- a/GitSpace/InitialView.swift
+++ b/GitSpace/InitialView.swift
@@ -35,6 +35,8 @@ struct InitialView: View {
                 ContentView(tabBarRouter: tabBarRouter)
                     .preferredColorScheme(selectedAppearance)
                     .environmentObject(UserStore(currentUserID: Auth.auth().currentUser?.uid ?? ""))
+            case .pending:
+                LoadingProgressView()
             case .signedOut:
                 SigninView(githubAuthManager: githubAuthManager, tabBarRouter: tabBarRouter)
                     .preferredColorScheme(selectedAppearance)

--- a/GitSpace/Sources/ViewModels/GitHubAuthManager.swift
+++ b/GitSpace/Sources/ViewModels/GitHubAuthManager.swift
@@ -75,7 +75,6 @@ final class GitHubAuthManager: ObservableObject {
             if let credential {
                 self.state = .pending
                 self.authentification.signIn(with: credential) { authResult, error in
-                    
                     if error != nil {
                         print("SignIn Error: \(String(describing: error?.localizedDescription))")
                     }
@@ -318,6 +317,12 @@ final class GitHubAuthManager: ObservableObject {
     // MARK: - Reauthenticate
     /// Reauthenticate User.
     func reauthenticateUser() async -> Void {
+        
+        // 자동 로그인 시 로그인뷰가 아닌 로딩뷰를 띄워주기 위한 상태 변경 (written by 예슬)
+        DispatchQueue.main.async {
+            self.state = .pending
+        }
+        
         guard let githubAccessToken = UserDefaults.standard.string(forKey: "AT") else {
             fatalError("Failed To Get Access Token.")
         }

--- a/GitSpace/Sources/ViewModels/GitHubAuthManager.swift
+++ b/GitSpace/Sources/ViewModels/GitHubAuthManager.swift
@@ -82,7 +82,6 @@ final class GitHubAuthManager: ObservableObject {
                     // User is signed in.
                     guard let oauthCredential = authResult?.credential as? OAuthCredential else {
                         return
-                        
                     }
                     // 아래 guard문을 삭제하지 않으면 로그인 시 무한 로딩에 걸림.
 //                    guard KeyChainManager.create(authCredential: credential) == true else { return }

--- a/GitSpace/Sources/ViewModels/GitHubAuthManager.swift
+++ b/GitSpace/Sources/ViewModels/GitHubAuthManager.swift
@@ -36,6 +36,7 @@ final class GitHubAuthManager: ObservableObject {
     
     enum SignInState {
         case signedIn
+        case pending
         case signedOut
     }
     
@@ -72,14 +73,20 @@ final class GitHubAuthManager: ObservableObject {
             }
             
             if let credential {
+                self.state = .pending
                 self.authentification.signIn(with: credential) { authResult, error in
+                    
                     if error != nil {
                         print("SignIn Error: \(String(describing: error?.localizedDescription))")
                     }
                     // User is signed in.
-                    guard let oauthCredential = authResult?.credential as? OAuthCredential else { return }
-                    guard KeyChainManager.create(authCredential: credential) == true else { return }
-                    print(KeyChainManager.read())
+                    guard let oauthCredential = authResult?.credential as? OAuthCredential else {
+                        return
+                        
+                    }
+                    // 아래 guard문을 삭제하지 않으면 로그인 시 무한 로딩에 걸림.
+//                    guard KeyChainManager.create(authCredential: credential) == true else { return }
+//                    print(KeyChainManager.read())
                     
                     // Github 사용자 데이터(name, email)을 가져오기 위해서 GitHub REST API request가 필요하다.
                     guard let githubAuthenticatedUserURL = URL(string: "https://api.github.com/user") else {

--- a/GitSpace/Sources/Views/Auth/SigninView.swift
+++ b/GitSpace/Sources/Views/Auth/SigninView.swift
@@ -41,9 +41,6 @@ struct SigninView: View {
                 .padding(.bottom, 30)
                 
             }
-            if isSignedIn {
-                LoadingProgressView()
-            }
         }
     }
 }


### PR DESCRIPTION
## 개요 및 관련 이슈
- #281 자동로그인과 관련하여 로티 로딩 뷰가 안뜨는 문제 해결 및 기타 코드 수정

## 작업 사항
- 로그인 시 실제 로그인 진행중에만 로딩뷰가 뜰 수 있도록 GitHubAuthManager의 signin() 내에서 credential이 nil이 아닐때만 self.state를 pending으로 바꿔주었습니다.

- InitialView.swift에서 signin state가 .pending일 때 LoadingProgressView를 띄우도록 하였습니다. 이로 인해 로그인 웹뷰에서 중도에 웹뷰를 나가거나 혹은 웹뷰가 뜨기 전 로딩뷰가 계속 뜨는 문제를 해결하였습니다.

- 자동로그인 로직 실행 시 signin()메소드를 타지 않아 state가 .pending으로 바뀌지 않기에 로딩뷰가 안뜨는 문제가 발생하였습니다. 이를 GitHubAuthManager 내의 reauthenticateUser() 메소드 시작 시 state를 pending으로 변경하여 로딩뷰가 뜰 수 있도록 코드를 수정하여 문제를 해결하였습니다.

