### PR TITLE
Feat/#291 ContirbutorListView-MoveToProfile-hanho

### DIFF
--- a/GitSpace/Sources/Views/Home/ContributorListCell.swift
+++ b/GitSpace/Sources/Views/Home/ContributorListCell.swift
@@ -17,8 +17,11 @@ struct ContributorGitSpaceUserListCell: View {
         
         GSCanvas.CustomCanvasView.init(style: .primary, content: {
             HStack(spacing: 15) {
-                /* 유저 프로필 이미지 */
-                GithubProfileImage(urlStr: targetUser.avatar_url, size: 40)
+                
+                NavigationLink(destination: UserProfileView(user: targetUser)) {
+                    /* 유저 프로필 이미지 */
+                    GithubProfileImage(urlStr: targetUser.avatar_url, size: 40)
+                }
                 
                 VStack(alignment: .leading) {
                     /* 유저네임 */
@@ -54,21 +57,24 @@ struct ContributorListCell: View {
         
         GSCanvas.CustomCanvasView.init(style: .primary, content: {
             HStack(spacing: 15) {
-                /* 유저 프로필 이미지 */
-                GithubProfileImage(urlStr: targetUser.avatar_url, size: 40)
                 
-                VStack(alignment: .leading) {
-                    /* 유저네임 */
-                    GSText.CustomTextView(
-                        style: .title3,
-                        string: targetUser.name ?? targetUser.login)
+                NavigationLink(destination: UserProfileView(user: targetUser)) {
+                    /* 유저 프로필 이미지 */
+                    GithubProfileImage(urlStr: targetUser.avatar_url, size: 40)
                     
-                    /* 유저ID */
-                    GSText.CustomTextView(
-                        style: .sectionTitle,
-                        string: targetUser.login)
-                } // VStack
-                .multilineTextAlignment(.leading)
+                    VStack(alignment: .leading) {
+                        /* 유저네임 */
+                        GSText.CustomTextView(
+                            style: .title3,
+                            string: targetUser.name ?? targetUser.login)
+                        
+                        /* 유저ID */
+                        GSText.CustomTextView(
+                            style: .sectionTitle,
+                            string: targetUser.login)
+                    } // VStack
+                    .multilineTextAlignment(.leading)
+                }
                 
                 Spacer()
             } // HStack

--- a/GitSpace/Sources/Views/Home/ContributorListView.swift
+++ b/GitSpace/Sources/Views/Home/ContributorListView.swift
@@ -31,6 +31,8 @@ struct ContributorListView: View {
             isDevided = false
         }
         
+        gitSpaceUserList.removeAll()
+        
         for someUser in contributorManager.contributors {
             if await userInfoManager.requestUserInfoWithGitHubID(githubID: someUser.id) != nil {
                 gitSpaceUserList.append(someUser.id)
@@ -63,11 +65,14 @@ struct ContributorListView: View {
                 
                 HStack {
                     if gitSpaceUserList.isEmpty && isDevided == true {
+                        // MARK: - 저장소의 기여자들 중 GitSpace User가 없을 경우
                         GSText.CustomTextView(
                             style: .title2,
                             string: "Oops!")
                     // if
-                    } else if gitSpaceUserList.count == 1 && gitSpaceUserList.contains(userInfoManager.currentUser?.githubID ?? 0) {
+                    } else if contributorManager.contributors.count == 1 && gitSpaceUserList.contains(userInfoManager.currentUser?.githubID ?? 0) {
+                        
+                        // MARK: - currentUser가 저장소의 유일한 기여자일 경우
                         GSText.CustomTextView(
                             style: .title2,
                             string: "Hello, \(userInfoManager.currentUser?.githubName ?? userInfoManager.currentUser!.githubLogin)!")
@@ -96,7 +101,7 @@ among the contributors to this repository.
 """
                         )
                         // if
-                    } else if gitSpaceUserList.count == 1 && gitSpaceUserList.contains(userInfoManager.currentUser?.githubID ?? 0) {
+                    } else if contributorManager.contributors.count == 1 && gitSpaceUserList.contains(userInfoManager.currentUser?.githubID ?? 0) {
                         GSText.CustomTextView(
                             style: .caption1,
                             string:
@@ -183,9 +188,10 @@ Please select a User to start chatting with.
             
         } // ScrollView
         .task {
+            await devideUser()            
+        }
+        .refreshable {
             await devideUser()
-            
-            print(userInfoManager.currentUser?.githubID ?? "error!: currentUser 정보 없음")
         }
         
     } // body


### PR DESCRIPTION
## 개요 및 관련 이슈
ContributorListView에서 유저 사진, 이름 등을 클릭할 때는 해당 유저의 프로필로 이동할 수 있도록 구현하였습니다.

## 작업 사항
### Feat
- GitSpace User의 경우 SendKnockView로 연결되는 것의 우선순위가 높다고 판단되어, 유저 사진을 눌렀을 경우에만 해당 유저의 프로필로 이동할 수 있도록 구현하였습니다.
- Non-GitSpace User의 경우 유저 사진, 이름을 클릭할 때 해당 유저의 프로필로 이동할 수 있도록 구현하였습니다.

### Fix
- Contributors가 여러명이고, CurrentUser만 GitSpaceUser일 경우 Description이 잘못 표시되는 이슈가 있었습니다.
    - 조건문의 ` gitSpaceUserList.count == 1 `를 ` contributorManager.contributors.count == 1 `로 변경하여 버그를 픽스하였습니다.