### PR TITLE
[Fix] #299 Contributors가 불러와지는 동안(.isLoading) ContributorListView에 진입할 경우, View가 깨지는 현상을 수정했습니다.

### DIFF
--- a/GitSpace/Sources/ViewModels/ContributorViewModel.swift
+++ b/GitSpace/Sources/ViewModels/ContributorViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 final class ContributorViewModel: ObservableObject {
     
@@ -43,7 +44,9 @@ final class ContributorViewModel: ObservableObject {
                     return .failure(error)
                 }
             }
-            self.isLoading = false
+            withAnimation(.easeInOut) {
+                self.isLoading = false
+            }
             return .success(())
         case .failure(let error):
             // 컨트리뷰터 목록을 가져올 수 없다는 에러

--- a/GitSpace/Sources/Views/Home/ContributorListView.swift
+++ b/GitSpace/Sources/Views/Home/ContributorListView.swift
@@ -25,7 +25,7 @@ struct ContributorListView: View {
     @State var gitSpaceUserList: [Int] = []
     @State var isDevided: Bool = false
     
-    func devideUser() async {
+    func divideUser() async {
         
         withAnimation(.easeInOut) {
             isDevided = false
@@ -194,10 +194,10 @@ Please select a User to start chatting with.
             
         } // ScrollView
         .task {
-            await devideUser()            
+            await divideUser()
         }
         .refreshable {
-            await devideUser()
+            await divideUser()
         }
         
     } // body

--- a/GitSpace/Sources/Views/Home/RepositoryDetailView.swift
+++ b/GitSpace/Sources/Views/Home/RepositoryDetailView.swift
@@ -50,6 +50,7 @@ struct RepositoryDetailView: View {
             } label: {
                 GSText.CustomTextView(style: .title3, string:"✊🏻  Knock Knock!")
             }
+            .disabled(contributorViewModel.isLoading)
             
             RichText(html: markdownString)
                 .colorScheme(.auto)


### PR DESCRIPTION
## 개요 및 관련 이슈
- Contributors가 불러와지는 동안(.isLoading) ContributorListView에 진입할 경우, View가 깨지는 현상을 수정했습니다.

## 작업 사항
- ` .disabled(contributorViewModel.isLoading) ` 코드를 추가 했습니다.
- 오타를 수정했습니다.
    - ` devideUser ` -> ` divideUser `

## 주요 로직(Optional)
```diff
GSNavigationLink(style: .primary) {
    ContributorListView(service: GitHubService(), repository: repository, contributorManager: contributorViewModel)
        .navigationTitle("Contributors")
} label: {
    GSText.CustomTextView(style: .title3, string:"✊🏻  Knock Knock!")
}
+    .disabled(contributorViewModel.isLoading)
```
