### PR TITLE
[Fix] #301 zombie user 문제를 해결했습니다. (임시방편)

### DIFF
--- a/GitSpace/InitialView.swift
+++ b/GitSpace/InitialView.swift
@@ -45,7 +45,7 @@ struct InitialView: View {
             }
         }
         .onViewDidLoad {
-            if githubAuthManager.authentification.currentUser != nil {
+            if githubAuthManager.authentification.currentUser != nil && UserDefaults.standard.string(forKey: "AT") != nil {
                 Task {
                     await githubAuthManager.reauthenticateUser()
                     githubAuthManager.state = .signedIn


### PR DESCRIPTION
## 개요 및 관련 이슈
- current user가 삭제되지 않아 발생하는 zombie user 문제를 해결했습니다. (정공법 아님)
- #301 

## 작업 사항
- UserDefault에 AT도 있는지 확인하여 로그인 상태 조건을 추가함

## 주요 로직(Optional)
```diff
.onViewDidLoad {
    if githubAuthManager.authentification.currentUser != nil 
+      && UserDefaults.standard.string(forKey: "AT") != nil 
        {
        Task {
            await githubAuthManager.reauthenticateUser()
            githubAuthManager.state = .signedIn
        }
    }
}
```
