### PR TITLE
[Feat / Chore] #303 SendKnockView | 최초 릴리즈 버전에 맞게 뷰를 수정했습니다.

### DIFF
--- a/GitSpace/Sources/Views/Knock/SendKnockView.swift
+++ b/GitSpace/Sources/Views/Knock/SendKnockView.swift
@@ -263,23 +263,24 @@ struct SendKnockView: View {
                         .padding(.horizontal)
                         
                         HStack(spacing: 10) {
-                            Button {
-                                print("이미지 첨부 버튼 탭")
-                            } label: {
-                                Image(systemName: "photo")
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(width: 20, height: 30)
-                            }
-
-                            Button {
-                                print("레포지토리 선택 버튼 탭")
-                            } label: {
-                                Image("RepositoryIcon")
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(width: 28, height: 23)
-                            }
+                            // MARK: 최초 릴리즈 버튼에서는 사용하지 않습니다.
+//                            Button {
+//                                print("이미지 첨부 버튼 탭")
+//                            } label: {
+//                                Image(systemName: "photo")
+//                                    .resizable()
+//                                    .aspectRatio(contentMode: .fit)
+//                                    .frame(width: 20, height: 30)
+//                            }
+//
+//                            Button {
+//                                print("레포지토리 선택 버튼 탭")
+//                            } label: {
+//                                Image("RepositoryIcon")
+//                                    .resizable()
+//                                    .aspectRatio(contentMode: .fit)
+//                                    .frame(width: 28, height: 23)
+//                            }
                             
                             GSTextEditor.CustomTextEditorView(style: .message, text: $knockMessage)
                             
@@ -369,23 +370,24 @@ struct SendKnockView: View {
                         .padding(.horizontal)
                         
                         HStack(spacing: 10) {
-                            Button {
-                                print("이미지 첨부 버튼 탭")
-                            } label: {
-                                Image(systemName: "photo")
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(width: 20, height: 30)
-                            }
-                            
-                            Button {
-                                print("레포지토리 선택 버튼 탭")
-                            } label: {
-                                Image("RepositoryIcon")
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(width: 28, height: 23)
-                            }
+                            // MARK: 최초 릴리즈 버튼에서는 사용하지 않습니다.
+//                            Button {
+//                                print("이미지 첨부 버튼 탭")
+//                            } label: {
+//                                Image(systemName: "photo")
+//                                    .resizable()
+//                                    .aspectRatio(contentMode: .fit)
+//                                    .frame(width: 20, height: 30)
+//                            }
+//
+//                            Button {
+//                                print("레포지토리 선택 버튼 탭")
+//                            } label: {
+//                                Image("RepositoryIcon")
+//                                    .resizable()
+//                                    .aspectRatio(contentMode: .fit)
+//                                    .frame(width: 28, height: 23)
+//                            }
                             
                             GSTextEditor.CustomTextEditorView(style: .message, text: $knockMessage)
                             

--- a/GitSpace/Sources/Views/Knock/SendKnockView.swift
+++ b/GitSpace/Sources/Views/Knock/SendKnockView.swift
@@ -16,9 +16,9 @@ struct SendKnockView: View {
     
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.dismiss) private var dismiss
-	@EnvironmentObject var userStore: UserStore
-	@EnvironmentObject var knockViewManager: KnockViewManager
-	@EnvironmentObject var pushNotificationManager: PushNotificationManager
+    @EnvironmentObject var userStore: UserStore
+    @EnvironmentObject var knockViewManager: KnockViewManager
+    @EnvironmentObject var pushNotificationManager: PushNotificationManager
     
     @Namespace var topID
     @Namespace var bottomID
@@ -28,9 +28,9 @@ struct SendKnockView: View {
     @State private var chatPurpose: String = ""
     @State private var knockMessage: String = ""
     @State private var showKnockGuide: Bool = false
-	
-	@State private var newKnock: Knock? = nil
-	@State private var isKnockSent: Bool = false
+    
+    @State private var newKnock: Knock? = nil
+    @State private var isKnockSent: Bool = false
     @State private var opacity: CGFloat = 0.4
     
     /**
@@ -39,7 +39,7 @@ struct SendKnockView: View {
      */
     @State var sendKnockToGitHubUser: GithubUser?
     @State private var targetUserInfo: UserInfo? = nil
-	
+    
     var body: some View {
         VStack {
             if let targetUserInfo {
@@ -56,69 +56,71 @@ struct SendKnockView: View {
                             .padding(.vertical, 10)
                             .padding(.horizontal, 5)
                         
-                        // MARK: - 안내 문구
-                        /// userName님께 보내는 첫 메세지네요!
-                        /// 노크를 해볼까요?
-                        VStack(spacing: 5) {
-                            HStack(spacing: 5) {
-                                Text("It's the first message to")
-                                Text("\(sendKnockToGitHubUser?.login ?? "NONO")!")
-                                    .bold()
-                            }
-                            
-                            HStack(spacing: 5) {
-                                Text("Would you like to")
-                                Button {
-                                    showKnockGuide.toggle()
-                                } label: {
-                                    Text("Knock")
+                        if !isKnockSent {
+                            // MARK: - 안내 문구
+                            /// userName님께 보내는 첫 메세지네요!
+                            /// 노크를 해볼까요?
+                            VStack(spacing: 5) {
+                                HStack(spacing: 5) {
+                                    Text("It's the first message to")
+                                    Text("\(sendKnockToGitHubUser?.login ?? "NONO")!")
                                         .bold()
                                 }
-                                Text("?")
-                                    .padding(.leading, -4)
+                                
+                                HStack(spacing: 5) {
+                                    Text("Would you like to")
+                                    Button {
+                                        showKnockGuide.toggle()
+                                    } label: {
+                                        Text("Knock")
+                                            .bold()
+                                    }
+                                    Text("?")
+                                        .padding(.leading, -4)
+                                }
                             }
-                        }
-                        .padding(.vertical, 15)
-                        
-                        // MARK: - 안내 문구
-                        /// 상대방에게 알려줄 채팅 목적을 선택해주세요.
-                        VStack(alignment: .center) {
-                            Text("Please specify the purpose of your chat to let")
-                            Text("your pal better understand your situation.")
-                        }
-                        .font(.footnote)
-                        .foregroundColor(.gsLightGray1)
-                        .padding(.bottom, 10)
-                        
-                        // MARK: - 채팅 목적 버튼
-                        HStack(spacing: 30) {
-                            GSButton.CustomButtonView(style: .secondary(
-                                isDisabled: false)) {
-                                    withAnimation(.easeInOut.speed(1.5)) {
-                                        chatPurpose = "offer"
-                                    }
-                                    withAnimation(.easeInOut.speed(1.5)) { proxy.scrollTo(bottomID) }
-                                } label: {
-                                    Text("🚀 Offer")
-                                        .font(.subheadline)
-                                        .foregroundColor(.black)
-                                        .bold()
-                                        .padding(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 12))
-                                } // button: Offer
+                            .padding(.vertical, 15)
                             
-                            GSButton.CustomButtonView(style: .secondary(
-                                isDisabled: false)) {
-                                    withAnimation(.easeInOut.speed(1.5)) {
-                                        chatPurpose = "question"
-                                    }
-                                    withAnimation(.easeInOut.speed(1.5)) { proxy.scrollTo(bottomID) }
-                                } label: {
-                                    Text("💡 Question")
-                                        .font(.subheadline)
-                                        .foregroundColor(.black)
-                                        .bold()
-                                } // button: Question
-                        } // HStack
+                            // MARK: - 안내 문구
+                            /// 상대방에게 알려줄 채팅 목적을 선택해주세요.
+                            VStack(alignment: .center) {
+                                Text("Please specify the purpose of your chat to let")
+                                Text("your pal better understand your situation.")
+                            }
+                            .font(.footnote)
+                            .foregroundColor(.gsLightGray1)
+                            .padding(.bottom, 10)
+                            
+                            // MARK: - 채팅 목적 버튼
+                            HStack(spacing: 30) {
+                                GSButton.CustomButtonView(style: .secondary(
+                                    isDisabled: false)) {
+                                        withAnimation(.easeInOut.speed(1.5)) {
+                                            chatPurpose = "offer"
+                                        }
+                                        withAnimation(.easeInOut.speed(1.5)) { proxy.scrollTo(bottomID) }
+                                    } label: {
+                                        Text("🚀 Offer")
+                                            .font(.subheadline)
+                                            .foregroundColor(.black)
+                                            .bold()
+                                            .padding(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 12))
+                                    } // button: Offer
+                                
+                                GSButton.CustomButtonView(style: .secondary(
+                                    isDisabled: false)) {
+                                        withAnimation(.easeInOut.speed(1.5)) {
+                                            chatPurpose = "question"
+                                        }
+                                        withAnimation(.easeInOut.speed(1.5)) { proxy.scrollTo(bottomID) }
+                                    } label: {
+                                        Text("💡 Question")
+                                            .font(.subheadline)
+                                            .foregroundColor(.black)
+                                            .bold()
+                                    } // button: Question
+                            } // HStack
+                        } // if
                         
                         // MARK: - 안내문구
                         /// userName에게 KnockMessage를 보내세요!
@@ -126,22 +128,35 @@ struct SendKnockView: View {
                         /// Knock message는 전송 이후에 삭제하거나 취소할 수 없습니다.
                         if !chatPurpose.isEmpty {
                             VStack(alignment: .center, spacing: 10) {
-                                VStack (alignment: .center) {
-                                    Text("Send your Knock messages to")
-                                    Text("\(sendKnockToGitHubUser?.login ?? "NONO")!")
-                                        .bold()
-                                } // VStack
                                 
-                                VStack(alignment: .center) {
-                                    Text("You can edit your Knock message before receiver")
-                                    Text("reads it, but can't cancel or delete chat once it is sent.")
-                                } // VStack
-                                .font(.footnote)
-                                .foregroundColor(.gsLightGray1)
-                                
-                                Divider()
-                                    .padding(.vertical, 15)
-                                    .frame(width: 300)
+                                if !isKnockSent {
+                                    VStack (alignment: .center) {
+                                        Text("Send your Knock messages to")
+                                        Text("\(sendKnockToGitHubUser?.login ?? "NONO")!")
+                                            .bold()
+                                    } // VStack
+                                    
+                                    VStack(alignment: .center) {
+                                        Text(
+"""
+You cannot modify or delete a message after it has been sent.
+Please write a message carefully.
+""")
+                                        // MARK: !!!
+                                        /// 노크 메세지가 수정 가능하면 대체할 텍스트 입니다.
+                                        //                                    Text("""
+                                        //You can edit your Knock message before receiver reads it,
+                                        //but can't cancel or delete chat once it is sent.
+                                        //""")
+                                    } // VStack
+                                    .font(.footnote)
+                                    .foregroundColor(.gsLightGray1)
+                                    .multilineTextAlignment(.center)
+                                    
+                                    Divider()
+                                        .padding(.vertical, 15)
+                                        .frame(width: 350)
+                                } // if
                                 
                                 HStack {
                                     RoundedRectangle(cornerRadius: 10)
@@ -154,31 +169,27 @@ struct SendKnockView: View {
                                         ? "Your Knock Message"
                                         : "Example Knock Message"
                                     )
-                                        .font(.footnote)
-                                        .foregroundColor(.gsLightGray1)
-                                        .bold()
+                                    .font(.footnote)
+                                    .foregroundColor(.gsLightGray1)
+                                    .bold()
                                     
                                     Spacer()
                                 } // HStack
                                 .padding(.leading, 20)
                                 
                                 VStack {
-                                    Text(
-                                        isKnockSent
-                                        ? "\(knockViewManager.newKnock?.knockMessage ?? "")"
-                                        : "\("Hi! This is Gildong from South Korea who’s\ncurrently studying Web programming.\nWould you mind giving me some time and\nadvising me on my future career path?\nThank you so much for your help!")"
-                                    )
-                                        .font(.system(size: 13, weight: .regular))
-                                        .foregroundColor(.black)
-                                        .padding(.horizontal, 20)
-                                        .padding(.vertical, 20)
-                                        .fixedSize(horizontal: false, vertical: true)
-                                        .background(
-                                            RoundedRectangle(cornerRadius: 17)
-                                                .fill(.white)
-                                                .shadow(color: Color(.systemGray5), radius: 8, x: 0, y: 2)
+                                    GSCanvas.CustomCanvasView.init(style: .primary, content: {
+                                        Text(
+                                            isKnockSent
+                                            ? "\(knockViewManager.newKnock?.knockMessage ?? "")"
+                                            : "\("Hi! This is Gildong from South Korea who’s\ncurrently studying Web programming.\nWould you mind giving me some time and\nadvising me on my future career path?\nThank you so much for your help!")"
                                         )
-                                        .padding(.horizontal, 15)
+                                        .font(.system(size: 13, weight: .regular))
+                                        .foregroundColor(.primary)
+                                        //                                        .padding(.horizontal, 10)
+                                        //                                        .padding(.vertical, 10)
+                                    })
+                                    .padding(10)
                                     
                                     if isKnockSent {
                                         Text("Your Knock Message has successfully been\ndelivered to **\(sendKnockToGitHubUser?.login ?? "")**")
@@ -194,7 +205,6 @@ struct SendKnockView: View {
                                             .padding(.vertical, 8)
                                     }
                                 } // VStack
-                                
                             } // VStack
                             .padding(.top, 80)
                         }
@@ -202,7 +212,7 @@ struct SendKnockView: View {
                         HStack {
                         }
                         .id(bottomID)
-                        .frame(height: 320)
+                        .frame(height: isKnockSent ? 5 : 320)
                         
                     } // ScrollView
                     //                .padding(.bottom, keyboardHandler.keyboardHeight)
@@ -220,54 +230,57 @@ struct SendKnockView: View {
                 
                 // MARK: - 텍스트 에디터
                 VStack {
-                    
                     if chatPurpose == "offer" {
                         
-                        Divider()
-                            .padding(.top, -8)
-                        
-                        HStack {
-                            Text("✍️ Offer-related message...")
-                                .foregroundColor(.gsLightGray1)
-                                .bold()
+                        if !isKnockSent {
+                            Divider()
+                                .padding(.top, -8)
                             
-                            Spacer()
-                            
-                            // MARK: 메세지 작성 취소 버튼
-                            /// chatPurpose가 없어지면서, 하단의 설명이 사라지게 된다.
-                            Button {
-                                self.endTextEditing()
-                                withAnimation(.easeInOut.speed(1.5)) {
-                                    chatPurpose = ""
-                                }
-                            } label: {
-                                Image(systemName: "xmark.circle.fill")
+                            HStack {
+                                Text("✍️ Offer-related message...")
                                     .foregroundColor(.gsLightGray1)
-                            }
-                        } // HStack
-                        .padding(.horizontal)
+                                    .bold()
+                                
+                                Spacer()
+                                
+                                // MARK: 메세지 작성 취소 버튼
+                                /// chatPurpose가 없어지면서, 하단의 설명이 사라지게 된다.
+                                Button {
+                                    self.endTextEditing()
+                                    withAnimation(.easeInOut.speed(1.5)) {
+                                        chatPurpose = ""
+                                    }
+                                } label: {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .foregroundColor(.gsLightGray1)
+                                }
+                            } // HStack
+                            .padding(.horizontal)
+                        }
                         
                         HStack(spacing: 10) {
                             // MARK: 최초 릴리즈 버전에서는 사용하지 않습니다.
-//                            Button {
-//                                print("이미지 첨부 버튼 탭")
-//                            } label: {
-//                                Image(systemName: "photo")
-//                                    .resizable()
-//                                    .aspectRatio(contentMode: .fit)
-//                                    .frame(width: 20, height: 30)
-//                            }
-//
-//                            Button {
-//                                print("레포지토리 선택 버튼 탭")
-//                            } label: {
-//                                Image("RepositoryIcon")
-//                                    .resizable()
-//                                    .aspectRatio(contentMode: .fit)
-//                                    .frame(width: 28, height: 23)
-//                            }
+                            //                            Button {
+                            //                                print("이미지 첨부 버튼 탭")
+                            //                            } label: {
+                            //                                Image(systemName: "photo")
+                            //                                    .resizable()
+                            //                                    .aspectRatio(contentMode: .fit)
+                            //                                    .frame(width: 20, height: 30)
+                            //                            }
+                            //
+                            //                            Button {
+                            //                                print("레포지토리 선택 버튼 탭")
+                            //                            } label: {
+                            //                                Image("RepositoryIcon")
+                            //                                    .resizable()
+                            //                                    .aspectRatio(contentMode: .fit)
+                            //                                    .frame(width: 28, height: 23)
+                            //                            }
                             
-                            GSTextEditor.CustomTextEditorView(style: .message, text: $knockMessage)
+                            
+                                GSTextEditor.CustomTextEditorView(style: .message, text: $knockMessage)
+                            
                             
                             Button {
                                 Task {
@@ -300,7 +313,7 @@ struct SendKnockView: View {
                                     
                                     await knockViewManager.createKnockOnFirestore(knock: newKnock)
                                     
-                                    isKnockSent = true
+                                    withAnimation(.easeInOut.speed(1.5)) { isKnockSent = true }
                                     knockMessage = ""
                                 }
                             } label: {
@@ -319,51 +332,55 @@ struct SendKnockView: View {
                         
                     } else if chatPurpose == "question" {
                         
-                        Divider()
-                            .padding(.top, -8)
-                        
-                        HStack {
-                            Text("✍️ Question-related message...")
-                                .foregroundColor(.gsLightGray1)
-                                .bold()
+                        if !isKnockSent {
+                            Divider()
+                                .padding(.top, -8)
                             
-                            Spacer()
-                            
-                            // MARK: 메세지 작성 취소 버튼
-                            /// chatPurpose가 없어지면서, 하단의 설명이 사라지게 된다.
-                            Button {
-                                self.endTextEditing()
-                                withAnimation(.easeInOut.speed(1.5)) {
-                                    chatPurpose = ""
-                                }
-                            } label: {
-                                Image(systemName: "xmark.circle.fill")
+                            HStack {
+                                Text("✍️ Question-related message...")
                                     .foregroundColor(.gsLightGray1)
-                            }
-                        } // HStack
-                        .padding(.horizontal)
+                                    .bold()
+                                
+                                Spacer()
+                                
+                                // MARK: 메세지 작성 취소 버튼
+                                /// chatPurpose가 없어지면서, 하단의 설명이 사라지게 된다.
+                                Button {
+                                    self.endTextEditing()
+                                    withAnimation(.easeInOut.speed(1.5)) {
+                                        chatPurpose = ""
+                                    }
+                                } label: {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .foregroundColor(.gsLightGray1)
+                                }
+                            } // HStack
+                            .padding(.horizontal)
+                        }
                         
                         HStack(spacing: 10) {
                             // MARK: 최초 릴리즈 버전에서는 사용하지 않습니다.
-//                            Button {
-//                                print("이미지 첨부 버튼 탭")
-//                            } label: {
-//                                Image(systemName: "photo")
-//                                    .resizable()
-//                                    .aspectRatio(contentMode: .fit)
-//                                    .frame(width: 20, height: 30)
-//                            }
-//
-//                            Button {
-//                                print("레포지토리 선택 버튼 탭")
-//                            } label: {
-//                                Image("RepositoryIcon")
-//                                    .resizable()
-//                                    .aspectRatio(contentMode: .fit)
-//                                    .frame(width: 28, height: 23)
-//                            }
+                            //                            Button {
+                            //                                print("이미지 첨부 버튼 탭")
+                            //                            } label: {
+                            //                                Image(systemName: "photo")
+                            //                                    .resizable()
+                            //                                    .aspectRatio(contentMode: .fit)
+                            //                                    .frame(width: 20, height: 30)
+                            //                            }
+                            //
+                            //                            Button {
+                            //                                print("레포지토리 선택 버튼 탭")
+                            //                            } label: {
+                            //                                Image("RepositoryIcon")
+                            //                                    .resizable()
+                            //                                    .aspectRatio(contentMode: .fit)
+                            //                                    .frame(width: 28, height: 23)
+                            //                            }
                             
-                            GSTextEditor.CustomTextEditorView(style: .message, text: $knockMessage)
+                            
+                                GSTextEditor.CustomTextEditorView(style: .message, text: $knockMessage)
+                            
                             
                             Button {
                                 Task {
@@ -396,7 +413,7 @@ struct SendKnockView: View {
                                     
                                     await knockViewManager.createKnockOnFirestore(knock: newKnock)
                                     
-                                    isKnockSent = true
+                                    withAnimation(.easeInOut.speed(1.5)) { isKnockSent = true }
                                     knockMessage = ""
                                 }
                             } label: {
@@ -429,7 +446,7 @@ struct SendKnockView: View {
                     ProfileDetailView()
                 } label: {
                     HStack(spacing: 5) {
-						AsyncImage(url: URL(string: "\(sendKnockToGitHubUser?.avatar_url ?? "")")) { image in
+                        AsyncImage(url: URL(string: "\(sendKnockToGitHubUser?.avatar_url ?? "")")) { image in
                             image
                                 .resizable()
                                 .aspectRatio(contentMode: .fit)
@@ -439,7 +456,7 @@ struct SendKnockView: View {
                             ProgressView()
                         } // AsyncImage
                         
-						Text("\(sendKnockToGitHubUser?.login ?? "NONO")")
+                        Text("\(sendKnockToGitHubUser?.login ?? "NONO")")
                             .bold()
                     } // HStack
                     .foregroundColor(.primary)

--- a/GitSpace/Sources/Views/Knock/SendKnockView.swift
+++ b/GitSpace/Sources/Views/Knock/SendKnockView.swift
@@ -14,6 +14,7 @@ enum TextEditorFocustState {
 
 struct SendKnockView: View {
     
+    @Environment(\.colorScheme) var colorScheme
     @Environment(\.dismiss) private var dismiss
 	@EnvironmentObject var userStore: UserStore
 	@EnvironmentObject var knockViewManager: KnockViewManager
@@ -44,7 +45,6 @@ struct SendKnockView: View {
             if let targetUserInfo {
                 ScrollViewReader { proxy in
                     ScrollView {
-                        
                         HStack {
                         }
                         .id(topID)
@@ -80,7 +80,6 @@ struct SendKnockView: View {
                         }
                         .padding(.vertical, 15)
                         
-                        
                         // MARK: - 안내 문구
                         /// 상대방에게 알려줄 채팅 목적을 선택해주세요.
                         VStack(alignment: .center) {
@@ -91,7 +90,6 @@ struct SendKnockView: View {
                         .foregroundColor(.gsLightGray1)
                         .padding(.bottom, 10)
                         
-                        
                         // MARK: - 채팅 목적 버튼
                         HStack(spacing: 30) {
                             GSButton.CustomButtonView(style: .secondary(
@@ -99,15 +97,13 @@ struct SendKnockView: View {
                                     withAnimation(.easeInOut.speed(1.5)) {
                                         chatPurpose = "offer"
                                     }
-                                    
                                     withAnimation(.easeInOut.speed(1.5)) { proxy.scrollTo(bottomID) }
-    //                                    .becomeFirstResponder()
                                 } label: {
                                     Text("🚀 Offer")
                                         .font(.subheadline)
-                                        .foregroundColor(.primary)
+                                        .foregroundColor(.black)
                                         .bold()
-                                        .padding(EdgeInsets(top: 0, leading: 13, bottom: 0, trailing: 13))
+                                        .padding(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 12))
                                 } // button: Offer
                             
                             GSButton.CustomButtonView(style: .secondary(
@@ -115,12 +111,11 @@ struct SendKnockView: View {
                                     withAnimation(.easeInOut.speed(1.5)) {
                                         chatPurpose = "question"
                                     }
-                                    
                                     withAnimation(.easeInOut.speed(1.5)) { proxy.scrollTo(bottomID) }
                                 } label: {
                                     Text("💡 Question")
                                         .font(.subheadline)
-                                        .foregroundColor(.primary)
+                                        .foregroundColor(.black)
                                         .bold()
                                 } // button: Question
                         } // HStack
@@ -130,7 +125,6 @@ struct SendKnockView: View {
                         /// 상대방이 Knock message를 확인하기 전까지 수정할 수 있습니다.
                         /// Knock message는 전송 이후에 삭제하거나 취소할 수 없습니다.
                         if !chatPurpose.isEmpty {
-                            
                             VStack(alignment: .center, spacing: 10) {
                                 VStack (alignment: .center) {
                                     Text("Send your Knock messages to")
@@ -152,8 +146,9 @@ struct SendKnockView: View {
                                 HStack {
                                     RoundedRectangle(cornerRadius: 10)
                                         .frame(width: 3, height: 15)
-                                        .foregroundColor(.gsGreenPrimary)
-                                    
+                                        .foregroundColor(colorScheme == .light
+                                                         ? .gsGreenPrimary
+                                                         : .gsYellowPrimary)
                                     Text(
                                         isKnockSent
                                         ? "Your Knock Message"
@@ -162,17 +157,19 @@ struct SendKnockView: View {
                                         .font(.footnote)
                                         .foregroundColor(.gsLightGray1)
                                         .bold()
+                                    
+                                    Spacer()
                                 } // HStack
-                                .padding(.leading, -75)
+                                .padding(.leading, 20)
                                 
                                 VStack {
-                                    
                                     Text(
                                         isKnockSent
                                         ? "\(knockViewManager.newKnock?.knockMessage ?? "")"
                                         : "\("Hi! This is Gildong from South Korea who’s\ncurrently studying Web programming.\nWould you mind giving me some time and\nadvising me on my future career path?\nThank you so much for your help!")"
                                     )
-                                        .font(.system(size: 10, weight: .regular))
+                                        .font(.system(size: 13, weight: .regular))
+                                        .foregroundColor(.black)
                                         .padding(.horizontal, 20)
                                         .padding(.vertical, 20)
                                         .fixedSize(horizontal: false, vertical: true)
@@ -180,7 +177,6 @@ struct SendKnockView: View {
                                             RoundedRectangle(cornerRadius: 17)
                                                 .fill(.white)
                                                 .shadow(color: Color(.systemGray5), radius: 8, x: 0, y: 2)
-                                            
                                         )
                                         .padding(.horizontal, 15)
                                     
@@ -235,6 +231,8 @@ struct SendKnockView: View {
                                 .foregroundColor(.gsLightGray1)
                                 .bold()
                             
+                            Spacer()
+                            
                             // MARK: 메세지 작성 취소 버튼
                             /// chatPurpose가 없어지면서, 하단의 설명이 사라지게 된다.
                             Button {
@@ -246,24 +244,11 @@ struct SendKnockView: View {
                                 Image(systemName: "xmark.circle.fill")
                                     .foregroundColor(.gsLightGray1)
                             }
-                            
-                            Spacer()
-                            
-                            // MARK: 키보드 내리기 버튼
-                            Button {
-                                self.endTextEditing()
-                            } label: {
-                                if keyboardHandler.keyboardHeight > 0 {
-                                    Image(systemName: "keyboard.chevron.compact.down")
-                                        .foregroundColor(.gsLightGray1)
-                                }
-                            }
-                            
                         } // HStack
                         .padding(.horizontal)
                         
                         HStack(spacing: 10) {
-                            // MARK: 최초 릴리즈 버튼에서는 사용하지 않습니다.
+                            // MARK: 최초 릴리즈 버전에서는 사용하지 않습니다.
 //                            Button {
 //                                print("이미지 첨부 버튼 탭")
 //                            } label: {
@@ -342,6 +327,8 @@ struct SendKnockView: View {
                                 .foregroundColor(.gsLightGray1)
                                 .bold()
                             
+                            Spacer()
+                            
                             // MARK: 메세지 작성 취소 버튼
                             /// chatPurpose가 없어지면서, 하단의 설명이 사라지게 된다.
                             Button {
@@ -353,24 +340,11 @@ struct SendKnockView: View {
                                 Image(systemName: "xmark.circle.fill")
                                     .foregroundColor(.gsLightGray1)
                             }
-                            
-                            Spacer()
-                            
-                            // MARK: 키보드 내리기 버튼
-                            Button {
-                                self.endTextEditing()
-                            } label: {
-                                if keyboardHandler.keyboardHeight > 0 {
-                                    Image(systemName: "keyboard.chevron.compact.down")
-                                        .foregroundColor(.gsLightGray1)
-                                }
-                            } // Button
-                            
                         } // HStack
                         .padding(.horizontal)
                         
                         HStack(spacing: 10) {
-                            // MARK: 최초 릴리즈 버튼에서는 사용하지 않습니다.
+                            // MARK: 최초 릴리즈 버전에서는 사용하지 않습니다.
 //                            Button {
 //                                print("이미지 첨부 버튼 탭")
 //                            } label: {
@@ -468,7 +442,7 @@ struct SendKnockView: View {
 						Text("\(sendKnockToGitHubUser?.login ?? "NONO")")
                             .bold()
                     } // HStack
-                    .foregroundColor(.black)
+                    .foregroundColor(.primary)
                 } // NavigationLink
             } // ToolbarItemGroup
         } // toolbar

--- a/GitSpace/Sources/Views/Knock/SendKnockView.swift
+++ b/GitSpace/Sources/Views/Knock/SendKnockView.swift
@@ -253,10 +253,10 @@ struct SendKnockView: View {
                             Button {
                                 self.endTextEditing()
                             } label: {
-                                Image(systemName: keyboardHandler.keyboardHeight > 0
-                                      ? "keyboard.chevron.compact.down"
-                                      : "")
-                                .foregroundColor(.gsLightGray1)
+                                if keyboardHandler.keyboardHeight > 0 {
+                                    Image(systemName: "keyboard.chevron.compact.down")
+                                        .foregroundColor(.gsLightGray1)
+                                }
                             }
                             
                         } // HStack
@@ -359,10 +359,10 @@ struct SendKnockView: View {
                             Button {
                                 self.endTextEditing()
                             } label: {
-                                Image(systemName: keyboardHandler.keyboardHeight > 0
-                                      ? "keyboard.chevron.compact.down"
-                                      : "")
-                                .foregroundColor(.gsLightGray1)
+                                if keyboardHandler.keyboardHeight > 0 {
+                                    Image(systemName: "keyboard.chevron.compact.down")
+                                        .foregroundColor(.gsLightGray1)
+                                }
                             } // Button
                             
                         } // HStack


### PR DESCRIPTION
## 개요 및 관련 이슈
### 최초 릴리즈 버전에 맞게 SendKnockView를 수정했습니다.
1. ~` View Profile ` NavigationLink를 해당 유저의 프로필로 이동할 수 있도록 연결합니다.~
    - UserProfileView 작업이 완료되면 연결 할 예정입니다.

2. 구현하지 못한 기능들과 최초 릴리즈 버전에 필요하지 않은 코드들을 주석 처리 또는 삭제했습니다.
    - TextEditor 섹션의 사진 / 코드 첨부 버튼 주석처리
    - `Offer` / `Question` 버튼 다크모드 대응
    - TextEditor 섹션의 키보드 숨기기 버튼 삭제

3. 노크 메세지를 보내고 난 후, 노크 메세지에 대한 Description들이 보이지 않게 수정하였습니다.
    - TextEditor와 Send 버튼의 경우, 기존의 뷰에서 Send 버튼에 변동이 있을 경우 (위치가 조정되거나 사라질 때)
    ` Publishing changes from within view updates is not allowed, this will cause undefined behavior. `
    위의 에러가 발생하는 문제가 있어 추후 작업을 통해 TextEditor와 Send 버튼도 보이지 않게 수정할 예정입니다.
    
    현재, 노크 메세지를 보내고 난 후에는 Send 버튼은 작동하지 않습니다. 

## 작업 사항
- TextEditor 섹션의 사진 / 코드 첨부 버튼 주석 처리
- `Offer` / `Question` 버튼 다크모드 대응
- TextEditor 섹션의 키보드 숨기기 버튼 삭제
- 노크 메세지를 보내고 난 후, 노크 메세지에 대한 Description들이 보이지 않게 분기 처리
