### PR TITLE
[Chore] 출시 버전에 맞춰서 사용하지 않은 Chat View의 컴포넌트들을 숨김 처리 했습니다.

### DIFF
--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -162,7 +162,10 @@ struct ChatRoomView: View {
     private var typeContentField : some View {
         HStack(spacing: 10) {
             
-            Button {
+            /*
+             v1.0.0 버전에서 사용하지 않는 버튼으로 주석 처리
+            
+             Button {
                 print("이미지 첨부 버튼 탭")
             } label: {
                 Image(systemName: "photo")
@@ -179,6 +182,7 @@ struct ChatRoomView: View {
                     .aspectRatio(contentMode: .fit)
                     .frame(width: 28, height: 23)
             }
+             */
             
             GSTextEditor.CustomTextEditorView(style: .message, text: $contentField)
                 .textInputAutocapitalization(.never)

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -96,7 +96,9 @@ struct ChatRoomView: View {
                         .padding(.horizontal, -8)
                 }
             }
-            
+            /*
+             v1.0.0 버전에서 사용하지 않는 툴바 아이템으로 주석 처리
+             
             ToolbarItem(placement: .navigationBarTrailing) {
                 NavigationLink {
                     makeChatRoomInfoViewToolbarItem()
@@ -105,6 +107,7 @@ struct ChatRoomView: View {
                         .foregroundColor(.primary)
                 }
             }
+             */
         }
         .task {
             // 유저가 읽지 않은 메세지 갯수를 요청해서 할당


### PR DESCRIPTION
## 개요 및 관련 이슈
- #308 

## 작업 사항
- ChatRoomView에서 ChatRoomInfoView로 연결하는 네비게이션 툴바 링크 제거
- 메세지 입력 필드 좌측 이미지 첨부 / 레포지토리 첨부 버튼 제거