### PR TITLE
Fix/#271 user profile view jegyun

### DIFF
--- a/GitSpace.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GitSpace.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/NuPlay/RichText",
       "state" : {
-        "revision" : "6bd367cba5a8245a4229b71317ef232da8e57f4e",
-        "version" : "2.1.3"
+        "revision" : "b104bcf390c645dba74597d69f34205c57638ee8",
+        "version" : "2.2.0"
       }
     },
     {

--- a/GitSpace/Sources/Views/Profile/CurrentUserProfileView.swift
+++ b/GitSpace/Sources/Views/Profile/CurrentUserProfileView.swift
@@ -163,7 +163,7 @@ struct CurrentUserProfileView: View {
                             .fontType(.system)
                             .linkOpenType(.SFSafariView())
                             .placeholder {
-                            ReadmeLoadingView()
+                                ReadmeLoadingView()
                         }
                     }
                 }

--- a/GitSpace/Sources/Views/Profile/MainProfileView.swift
+++ b/GitSpace/Sources/Views/Profile/MainProfileView.swift
@@ -20,7 +20,6 @@ struct MainProfileView: View {
         .navigationTitle("")
         .toolbar {
             ToolbarItemGroup(placement: .navigationBarTrailing){
-                 
                 Button {
                     showGuideCenter.toggle()
                 } label: {

--- a/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
+++ b/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
@@ -253,7 +253,7 @@ struct TargetUserProfileView: View {
                             .fontType(.system)
                             .linkOpenType(.SFSafariView())
                             .placeholder {
-                            ReadmeLoadingView()
+                                ReadmeLoadingView()
                         }
                     }
                 }

--- a/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
+++ b/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
@@ -253,7 +253,7 @@ struct TargetUserProfileView: View {
                             .fontType(.system)
                             .linkOpenType(.SFSafariView())
                             .placeholder {
-                                ReadmeLoadingView()
+                            ReadmeLoadingView()
                         }
                     }
                 }


### PR DESCRIPTION
## 개요 및 관련 이슈
- 프로필뷰의 버그를 제거하고, 프로필이 들어가는 모든 뷰에서 디자인 통일 작업 및 개선 작업을 진행하였습니다.

## 작업 사항
- CurrentUserProfileView, TargetUserProfileView의 스크롤바 제거
- TargetUserProfileView(특정 유저의 프로필)와 CurrentUserProfileView(사용자의 프로필) 디자인 통일 작업
- TargetUserProfileView이 만약 자기자신의 프로필을 보여주고 있다면 Follow 및 Knock 버튼을 제거
- 유저가 깃허브에서 설정한 이름이 없다면 깃허브 아이디만 보여주고, 유저가 깃허브에서 설정한 이름이 있다면 이름과 아이디 모두 보여주도록 수정
- TargetUserProfileView에서 팔로우 / 팔로잉 버튼의 기능 동작하도록 구현
- TargetUserProfileView에서 GitSpace 유저가 아니라면 팔로우 / 팔로잉 버튼만 보이도록 구현
- TargetUserProfileView, CurrentUserProfileView에서 README를 불러올 수 없을 때 메시지를 띄우지 않고 이미지가 포함된 뷰를 보여주도록 수정
- README 불러올 때 로딩 뷰 수정
