### PR TITLE
[Feat] GSTextEditor 디자인 시스템에 메세지 전송 가능 유효성 검사 체크 로직을 추가했습니다.

### DIFF
--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -201,15 +201,7 @@ struct ChatRoomView: View {
     private var addContentButton : some View {
         Button {
             Task {
-                // 상대방의 id로 유저를 가져옵니다.
-                let sentFrom = userStore.user?.githubLogin
-				async let opponentUser = userStore.requestUserInfoWithID(userID: chat.targetUserID)
-                
-				// TODO: - PUSH NOTIFICATION 수정 필요
-				// !!!: DUE TO USERINFO MODEL UPDATE
-                
                 await addContent()
-                
             }
         } label: {
             Image(systemName: contentField.isEmpty ? "paperplane" : "paperplane.fill")

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -185,8 +185,6 @@ struct ChatRoomView: View {
              */
             
             contentTextEditor
-            
-            addContentButton
                 
         }
         .padding(.bottom, 15)
@@ -202,20 +200,9 @@ struct ChatRoomView: View {
             .disableAutocorrection(true)
     }
 
-    // MARK: Button : 메세지 추가(보내기)
-    private var addContentButton : some View {
-        Button {
             Task {
                 await addContent()
             }
-        } label: {
-            Image(systemName: contentField.isEmpty ? "paperplane" : "paperplane.fill")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 22, height: 22)
-                .foregroundColor(contentField.isEmpty
-                                 ? .gsGray2
-                                 : .primary)
         }
     }
     

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -208,7 +208,9 @@ struct ChatRoomView: View {
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 22, height: 22)
-                .foregroundColor(contentField.isEmpty ? .gsGray2 : .primary)
+                .foregroundColor(contentField.isEmpty
+                                 ? .gsGray2
+                                 : .primary)
         }
     }
     

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -184,9 +184,7 @@ struct ChatRoomView: View {
             }
              */
             
-            GSTextEditor.CustomTextEditorView(style: .message, text: $contentField)
-                .textInputAutocapitalization(.never)
-                .disableAutocorrection(true)
+            contentTextEditor
             
             addContentButton
                 
@@ -195,6 +193,13 @@ struct ChatRoomView: View {
         .padding(.vertical, -3)
         .padding(.horizontal, 15)
         .foregroundColor(.primary)
+    }
+    
+    private var contentTextEditor: some View {
+        GSTextEditor.CustomTextEditorView(style: .message,
+                                          text: $contentField)
+            .textInputAutocapitalization(.never)
+            .disableAutocorrection(true)
     }
 
     // MARK: Button : 메세지 추가(보내기)
@@ -213,8 +218,6 @@ struct ChatRoomView: View {
                                  : .primary)
         }
     }
-    
-    
     
     // MARK: -Methods
     // MARK: Method - 유저가 읽지 않은 메세지 갯수를 0으로 초기화하고 DB에 업데이트하는 함수

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -189,7 +189,7 @@ struct ChatRoomView: View {
                 .disableAutocorrection(true)
             
             addContentButton
-                .disabled(contentField.isEmpty)
+                
         }
         .padding(.bottom, 15)
         .padding(.vertical, -3)

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -193,17 +193,18 @@ struct ChatRoomView: View {
         .foregroundColor(.primary)
     }
     
+    // MARK: GSTextEditor - 메세지 입력 필드와 전송 버튼
     private var contentTextEditor: some View {
         GSTextEditor.CustomTextEditorView(style: .message,
-                                          text: $contentField)
-            .textInputAutocapitalization(.never)
-            .disableAutocorrection(true)
-    }
-
+                                          text: $contentField,
+                                          sendableImage: "paperplane.fill",
+                                          unSendableImage: "paperplane") {
             Task {
                 await addContent()
             }
         }
+                                          .textInputAutocapitalization(.never)
+                                          .disableAutocorrection(true)
     }
     
     // MARK: -Methods

--- a/GitSpace/Sources/Views/Knock/SendKnockView.swift
+++ b/GitSpace/Sources/Views/Knock/SendKnockView.swift
@@ -279,6 +279,7 @@ Please write a message carefully.
                             //                            }
                             
                             
+                            // FIXME: 노크 전송 버튼 disabled 조건에 isKnockSent 추가 필요함! From. 영이 -> To. 노이
                             GSTextEditor.CustomTextEditorView(style: .message,
                                                               text: $knockMessage,
                                                               sendableImage: "paperplane.fill",

--- a/GitSpace/Sources/Views/Knock/SendKnockView.swift
+++ b/GitSpace/Sources/Views/Knock/SendKnockView.swift
@@ -279,10 +279,10 @@ Please write a message carefully.
                             //                            }
                             
                             
-                                GSTextEditor.CustomTextEditorView(style: .message, text: $knockMessage)
-                            
-                            
-                            Button {
+                            GSTextEditor.CustomTextEditorView(style: .message,
+                                                              text: $knockMessage,
+                                                              sendableImage: "paperplane.fill",
+                                                              unSendableImage: "paperplane") {
                                 Task {
                                     let newKnock = Knock(
                                         date: .now,
@@ -316,15 +316,7 @@ Please write a message carefully.
                                     withAnimation(.easeInOut.speed(1.5)) { isKnockSent = true }
                                     knockMessage = ""
                                 }
-                            } label: {
-                                Image(systemName: "paperplane")
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(width: 22, height: 22)
-                                    .foregroundColor(knockMessage.isEmpty ? .gsGray2 : .primary)
                             }
-                            .disabled(knockMessage.isEmpty || isKnockSent)
-                            
                         } // HStack
                         .foregroundColor(.primary)
                         .padding(.horizontal)
@@ -379,10 +371,11 @@ Please write a message carefully.
                             //                            }
                             
                             
-                                GSTextEditor.CustomTextEditorView(style: .message, text: $knockMessage)
                             
-                            
-                            Button {
+                            GSTextEditor.CustomTextEditorView(style: .message,
+                                                              text: $knockMessage,
+                                                              sendableImage: "paperplane.fill",
+                                                              unSendableImage: "paperplane") {
                                 Task {
                                     let newKnock = Knock(
                                         date: .now,
@@ -416,14 +409,7 @@ Please write a message carefully.
                                     withAnimation(.easeInOut.speed(1.5)) { isKnockSent = true }
                                     knockMessage = ""
                                 }
-                            } label: {
-                                Image(systemName: "paperplane")
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(width: 22, height: 22)
-                                    .foregroundColor(knockMessage.isEmpty ? .gsGray2 : .primary)
                             }
-                            .disabled(knockMessage.isEmpty || isKnockSent)
                         } // HStack
                         .foregroundColor(.primary)
                         .padding(.horizontal)

--- a/GitSpace/Utilities/Components/GSTextEditor.swift
+++ b/GitSpace/Utilities/Components/GSTextEditor.swift
@@ -73,6 +73,8 @@ struct GSTextEditor {
             return label.frame.width
         }
         
+        private var 
+        
         // MARK: -Methods
         // MARK: Method - 시작 textEditor 높이를 세팅해주는 메서드
         private func setTextEditorStartHeight() {

--- a/GitSpace/Utilities/Components/GSTextEditor.swift
+++ b/GitSpace/Utilities/Components/GSTextEditor.swift
@@ -21,7 +21,7 @@ struct GSTextEditor {
     }
     
     // MARK: -View
-    struct CustomTextEditorView: View {
+    struct CustomTextEditorView : View {
         
         // MARK: -Properties
         // MARK: Stored Properties
@@ -83,6 +83,7 @@ struct GSTextEditor {
         
         private var isMessageSendable: Bool {
             let messageText = text.wrappedValue
+            
             guard messageText.isEmpty == false else { return false }
             
             let pattern: String = "^[ \n]*$"

--- a/GitSpace/Utilities/Components/GSTextEditor.swift
+++ b/GitSpace/Utilities/Components/GSTextEditor.swift
@@ -25,13 +25,15 @@ struct GSTextEditor {
         
         // MARK: -Properties
         // MARK: Stored Properties
+        let const = Constant.TextEditorConst.self
+        
+        // MARK: TextEditor 관련 프로퍼티
         let style: GSTextEditorStyle
         let text: Binding<String>
         let font: Font
         let lineSpace: CGFloat
-        let const = Constant.TextEditorConst.self
-        @State private var textEditorHeight: CGFloat = 0
         
+        @State private var textEditorHeight: CGFloat = 0
         @State private var stateTextWidth: CGFloat = 0
         
         // MARK: Computed Properties

--- a/GitSpace/Utilities/Components/GSTextEditor.swift
+++ b/GitSpace/Utilities/Components/GSTextEditor.swift
@@ -152,12 +152,18 @@ struct GSTextEditor {
             style: GSTextEditorStyle,
             text: Binding<String>,
             font: Font = .body,
-            lineSpace: CGFloat = 2
+            lineSpace: CGFloat = 2,
+            sendableImage: String,
+            unSendableImage: String,
+            action: @escaping () -> Void
         ) {
             self.style = style
             self.text = text
             self.font = font
             self.lineSpace = lineSpace
+            self.sendableImage = sendableImage
+            self.unSendableImage = unSendableImage
+            self.action = action
         }
         
         

--- a/GitSpace/Utilities/Components/GSTextEditor.swift
+++ b/GitSpace/Utilities/Components/GSTextEditor.swift
@@ -75,7 +75,19 @@ struct GSTextEditor {
             return label.frame.width
         }
         
-        private var 
+        private var isMessageSendable: Bool {
+            let messageText = text.wrappedValue
+            guard messageText.isEmpty == false else { return false }
+            
+            let pattern: String = "^[ \n]*$"
+            
+            if messageText.range(of: pattern,
+                                 options: .regularExpression) != nil {
+                return false
+            }
+            
+            return true
+        }
         
         // MARK: -Methods
         // MARK: Method - 시작 textEditor 높이를 세팅해주는 메서드
@@ -179,4 +191,5 @@ struct GSTextEditor {
         }
     }
 }
+
 

--- a/GitSpace/Utilities/Components/GSTextEditor.swift
+++ b/GitSpace/Utilities/Components/GSTextEditor.swift
@@ -33,6 +33,12 @@ struct GSTextEditor {
         let font: Font
         let lineSpace: CGFloat
         
+        // MARK: SendButton 관련 프로퍼티
+        let sendableImage: String
+        let unSendableImage: String
+        let action: () -> Void
+        
+        
         @State private var textEditorHeight: CGFloat = 0
         @State private var stateTextWidth: CGFloat = 0
         

--- a/GitSpace/Utilities/Components/GSTextEditor.swift
+++ b/GitSpace/Utilities/Components/GSTextEditor.swift
@@ -171,34 +171,51 @@ struct GSTextEditor {
         var body: some View {
             switch style {
             case .message:
-                GeometryReader { proxy in
-                    TextEditor(text: text)
-                        .font(font)
-                        .lineSpacing(lineSpace)
-                        .frame(maxHeight: textEditorHeight)
-                        .padding(.horizontal, const.TEXTEDITOR_INSET_HORIZONTAL)
-                        .padding(.bottom, -3)
-                        .overlay {
-                            RoundedRectangle(cornerRadius: const.TEXTEDITOR_STROKE_CORNER_RADIUS)
-                                .stroke()
-                                .foregroundColor(.gsGray2)
-                        }
-                        .onAppear {
-                            setTextEditorStartHeight()
-                        }
-                        .onChange(of: text.wrappedValue) { n in
-                            // FIXME: 현재 버퍼값으로는 텍스트 길이와 에디터 길이 사이의 공식을 정확하게 구하지 못해서 당장 작동은 하지만 정확한 값을 구해서 수정 필요 By. 태영
-                            let textEditorWidth = proxy.size.width - (const.TEXTEDITOR_INSET_HORIZONTAL * 2 + 10)
-                            let autoLineBreakCounter = autoLineBreakCount(textEditorWidth: textEditorWidth)
-                            let multiTextEditorWidth = textEditorWidth - CGFloat(autoLineBreakCounter * 2)
-                            
-                            updateTextEditorCurrentHeight(textEditorWidth: multiTextEditorWidth)
-                        }
-                        .onChange(of: textWidth) { newValue in
-                            stateTextWidth = newValue
-                        }
+                HStack {
+                    GeometryReader { proxy in
+                        TextEditor(text: text)
+                            .font(font)
+                            .lineSpacing(lineSpace)
+                            .frame(maxHeight: textEditorHeight)
+                            .padding(.horizontal, const.TEXTEDITOR_INSET_HORIZONTAL)
+                            .padding(.bottom, -3)
+                            .overlay {
+                                RoundedRectangle(cornerRadius: const.TEXTEDITOR_STROKE_CORNER_RADIUS)
+                                    .stroke()
+                                    .foregroundColor(.gsGray2)
+                            }
+                            .onAppear {
+                                setTextEditorStartHeight()
+                            }
+                            .onChange(of: text.wrappedValue) { n in
+                                // FIXME: 현재 버퍼값으로는 텍스트 길이와 에디터 길이 사이의 공식을 정확하게 구하지 못해서 당장 작동은 하지만 정확한 값을 구해서 수정 필요 By. 태영
+                                let textEditorWidth = proxy.size.width - (const.TEXTEDITOR_INSET_HORIZONTAL * 2 + 10)
+                                let autoLineBreakCounter = autoLineBreakCount(textEditorWidth: textEditorWidth)
+                                let multiTextEditorWidth = textEditorWidth - CGFloat(autoLineBreakCounter * 2)
+                                
+                                updateTextEditorCurrentHeight(textEditorWidth: multiTextEditorWidth)
+                            }
+                            .onChange(of: textWidth) { newValue in
+                                stateTextWidth = newValue
+                            }
+                    }
+                    .frame(maxHeight: textEditorHeight)
+                    
+                    Button {
+                        action()
+                    } label: {
+                        Image(systemName: isMessageSendable
+                              ? sendableImage
+                              : unSendableImage)
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 22, height: 22)
+                            .foregroundColor(isMessageSendable
+                                             ? .gsGray2
+                                             : .primary)
+                    }
+                    .disabled(!isMessageSendable)
                 }
-                .frame(maxHeight: textEditorHeight)
             }
         }
     }

--- a/GitSpace/Utilities/Components/GSTextEditor.swift
+++ b/GitSpace/Utilities/Components/GSTextEditor.swift
@@ -83,16 +83,22 @@ struct GSTextEditor {
         // TextEditor (줄 갯수 * 폰트 높이) + (줄 갯수 * 자간) + 잘림 방지 여유 공간
         private func updateTextEditorCurrentHeight(textEditorWidth: CGFloat) {
             
-            let floatNewLineCounter = CGFloat(newLineCounter) // 개행문자 갯수
-            let floatAutoLineBreakCount = CGFloat(autoLineBreakCount(textEditorWidth: textEditorWidth)) // 텍스트 길이에 의한 자동 줄바꿈 갯수
-            let floatTotalLineCount = floatNewLineCounter + floatAutoLineBreakCount // 총 라인 갯수
+            // 개행문자 갯수
+            let floatNewLineCounter = CGFloat(newLineCounter)
+            
+            // 텍스트 길이에 의한 자동 줄바꿈 갯수
+            let floatAutoLineBreakCount = CGFloat(autoLineBreakCount(textEditorWidth: textEditorWidth))
+            
+            // 총 라인 갯수
+            let floatTotalLineCount = floatNewLineCounter + floatAutoLineBreakCount
             
             // 라인 갯수로 계산한 현재 Editor 높이
             let tempTextEditorHeight = (floatTotalLineCount * mainFontLineHeight)
             + floatTotalLineCount * lineSpace
             + const.TEXTEDITOR_FRAME_HEIGHT_FREESPACE
             
-            let floatMaxLineCount = CGFloat(const.TEXTEDITOR_MAX_LINE_COUNT) // 최대 줄 갯수
+            // 최대 줄 갯수
+            let floatMaxLineCount = CGFloat(const.TEXTEDITOR_MAX_LINE_COUNT)
             
             // 최대 줄 갯수 기준 Editor 높이
             let maxHeight = mainFontLineHeight * floatMaxLineCount

--- a/GitSpace/Utilities/Components/GSTextEditor.swift
+++ b/GitSpace/Utilities/Components/GSTextEditor.swift
@@ -81,6 +81,7 @@ struct GSTextEditor {
             return label.frame.width
         }
         
+        // 메세지 문자열이 비어있는지, 공백으로만 이루어져있는지를 체크해서 메시지 전송 가능 여부를 반환하는 연산 프로퍼티
         private var isMessageSendable: Bool {
             let messageText = text.wrappedValue
             guard messageText.isEmpty == false else { return false }

--- a/GitSpace/Utilities/Components/GSTextEditor.swift
+++ b/GitSpace/Utilities/Components/GSTextEditor.swift
@@ -83,16 +83,12 @@ struct GSTextEditor {
         
         private var isMessageSendable: Bool {
             let messageText = text.wrappedValue
-            
             guard messageText.isEmpty == false else { return false }
-            
             let pattern: String = "^[ \n]*$"
-            
             if messageText.range(of: pattern,
                                  options: .regularExpression) != nil {
                 return false
             }
-            
             return true
         }
         


### PR DESCRIPTION
## 개요 및 관련 이슈
- #310 

## 작업 사항
- 공백 / 개행문자만 존재하는 케이스를 검사하는 정규식 패턴 구현
- GSTextEditor 디자인 시스템으로 문자열 검사 로직 위치 변경
- 메세지 전송 버튼을 디자인 시스템 내부로 이동

## 주요 로직(Optional)
```swift
// MARK: SendButton 관련 프로퍼티
        let sendableImage: String
        let unSendableImage: String
        let action: () -> Void

---

private var isMessageSendable: Bool {
            let messageText = text.wrappedValue
            guard messageText.isEmpty == false else { return false }
            let pattern: String = "^[ \n]*$"
            if messageText.range(of: pattern,
                                 options: .regularExpression) != nil {
                return false
            }
            return true
        }
```
