### PR TITLE
[Fix] GSTextEditor 전송 버튼의 삼항연산자 순서를 변경했습니다.

### DIFF
--- a/GitSpace/Utilities/Components/GSTextEditor.swift
+++ b/GitSpace/Utilities/Components/GSTextEditor.swift
@@ -209,8 +209,8 @@ struct GSTextEditor {
                             .aspectRatio(contentMode: .fit)
                             .frame(width: 22, height: 22)
                             .foregroundColor(isMessageSendable
-                                             ? .gsGray2
-                                             : .primary)
+                                             ? .primary
+                                             : .gsGray2)
                     }
                     .disabled(!isMessageSendable)
                 }


### PR DESCRIPTION
## 개요 및 관련 이슈
- #310 
