### PR TITLE
[Add] #259 Tagging에서 삭제 기능을 추가했습니다.

### DIFF
--- a/GitSpace/Sources/ViewModels/TagViewModel.swift
+++ b/GitSpace/Sources/ViewModels/TagViewModel.swift
@@ -129,11 +129,11 @@ final class TagViewModel: ObservableObject {
     func updateRepositoryTag() {
         
     }
+    */
     
     // MARK: Delete Repository Tag
     /// 선택된 레포지토리의 태그를 삭제합니다.
-    func deleteRepositoryTag() {
+    func deleteRepositoryTag(_ tags: [Tag], to selectedRepositoryName: String) async -> Void {
         
     }
-    */
 }

--- a/GitSpace/Sources/ViewModels/TagViewModel.swift
+++ b/GitSpace/Sources/ViewModels/TagViewModel.swift
@@ -106,7 +106,7 @@ final class TagViewModel: ObservableObject {
     
     // MARK: Register Repository Tag
     /// 선택된 레포지토리에 새로운 태그를 추가합니다.
-    func addRepositoryTag(_ tags: [Tag], repositoryFullname: String) async -> Void {
+    func addRepositoryTag(_ tags: [Tag], to selectedRepositoryName: String) async -> Void {
         do {
             for tag in tags {
                 try await database.collection(const.COLLECTION_USER_INFO)
@@ -114,7 +114,7 @@ final class TagViewModel: ObservableObject {
                     .collection("Tag")
                     .document(tag.id)
                     .updateData([
-                        "repositories": FieldValue.arrayUnion([repositoryFullname])
+                        "repositories": FieldValue.arrayUnion([selectedRepositoryName])
                     ])
             }
         } catch {

--- a/GitSpace/Sources/ViewModels/TagViewModel.swift
+++ b/GitSpace/Sources/ViewModels/TagViewModel.swift
@@ -134,6 +134,18 @@ final class TagViewModel: ObservableObject {
     // MARK: Delete Repository Tag
     /// 선택된 레포지토리의 태그를 삭제합니다.
     func deleteRepositoryTag(_ tags: [Tag], to selectedRepositoryName: String) async -> Void {
-        
+        do {
+            for tag in tags {
+                try await database.collection(const.COLLECTION_USER_INFO)
+                    .document(Auth.auth().currentUser?.uid ?? "")
+                    .collection(const.COLLECTION_TAG)
+                    .document(tag.id)
+                    .updateData([
+                        const.FIELD_REPOSITORIES: FieldValue.arrayRemove([selectedRepositoryName])
+                    ])
+            }
+        } catch {
+            print("Error-\(#file)-\(#function): \(error.localizedDescription)")
+        }
     }
 }

--- a/GitSpace/Sources/ViewModels/TagViewModel.swift
+++ b/GitSpace/Sources/ViewModels/TagViewModel.swift
@@ -111,14 +111,14 @@ final class TagViewModel: ObservableObject {
             for tag in tags {
                 try await database.collection(const.COLLECTION_USER_INFO)
                     .document(Auth.auth().currentUser?.uid ?? "")
-                    .collection("Tag")
+                    .collection(const.COLLECTION_TAG)
                     .document(tag.id)
                     .updateData([
-                        "repositories": FieldValue.arrayUnion([selectedRepositoryName])
+                        const.FIELD_REPOSITORIES: FieldValue.arrayUnion([selectedRepositoryName])
                     ])
             }
         } catch {
-            print("Error")
+            print("Error-\(#file)-\(#function): \(error.localizedDescription)")
         }
     }
     

--- a/GitSpace/Sources/Views/Home/AddTagSheetView.swift
+++ b/GitSpace/Sources/Views/Home/AddTagSheetView.swift
@@ -48,7 +48,7 @@ struct AddTagSheetView: View {
         if shouldBlankTag && shouldExistTag {
             Task {
                 guard let newTag = await tagViewModel.registerTag(tagName: trimmedTagInput) else {
-                    print(#function, "Failed Add New Tag.")
+                    print("Error-\(#file)-\(#function): Failed Add New Tag.")
                     return
                 }
                 withAnimation {
@@ -85,8 +85,10 @@ struct AddTagSheetView: View {
         switch beforeView {
         case .repositoryDetailView:
             Task {
-                // FIXME: 실제 레포 이름 가져오기
-                guard let repository = selectedRepository else { return }
+                guard let repository = selectedRepository else {
+                    print("Error-\(#file)-\(#function): Failed Optional unwrapping.")
+                    return
+                }
                 await tagViewModel.addRepositoryTag(preSelectedTags, repositoryFullname: repository.fullName)
             }
         case .starredView:

--- a/GitSpace/Sources/Views/Home/AddTagSheetView.swift
+++ b/GitSpace/Sources/Views/Home/AddTagSheetView.swift
@@ -98,10 +98,15 @@ struct AddTagSheetView: View {
                     print("Error-\(#file)-\(#function): Failed Optional unwrapping.")
                     return
                 }
-                await tagViewModel.addRepositoryTag(preSelectedTags, to: repository.fullName)
+                if !selectedTags.isEmpty {
+                    await tagViewModel.addRepositoryTag(preSelectedTags, to: repository.fullName)
+                }
+                if !deselectedTags.isEmpty {
+                    await tagViewModel.deleteRepositoryTag(deselectedTags, to: repository.fullName)
+                }
             }
         case .starredView:
-            if !preSelectedTags.isEmpty {
+            if !selectedTags.isEmpty {
                 repositoryViewModel.filterRepository(selectedTagList: preSelectedTags)
             } else {
                 repositoryViewModel.filteredRepositories = repositoryViewModel.repositories

--- a/GitSpace/Sources/Views/Home/AddTagSheetView.swift
+++ b/GitSpace/Sources/Views/Home/AddTagSheetView.swift
@@ -80,7 +80,16 @@ struct AddTagSheetView: View {
         }
     }
     
-    func addSelectedTagToPreSelectedTags() {
+    // MARK: Register Selected Tags
+    /// - Description
+    /// 선택한 태그들을 실제로 등록합니다.
+    /// 이전 뷰가 StarredView이면 Selected Tags 기능에 등록하고, RepositoryDetailView이면 Repository에 적용합니다.
+    func registerSelectedTags() {
+        /*
+         모달을 내리기 전에
+         사용자가 선택한 태그들(selectedTags)를
+         preSelectedTag(Binding Property)에 추가한다.
+        */
         preSelectedTags = selectedTags
         switch beforeView {
         case .repositoryDetailView:
@@ -208,12 +217,7 @@ struct AddTagSheetView: View {
                     
                     ToolbarItem(placement: .navigationBarTrailing) {
                         Button {
-                            /*
-                             모달을 내리기 전에
-                             사용자가 선택한 태그들(selectedTags)를
-                             preSelectedTag에 추가한다.
-                             */
-                            addSelectedTagToPreSelectedTags()
+                            registerSelectedTags()
                             dismiss()
                         } label: {
                             Text("Done")

--- a/GitSpace/Sources/Views/Home/AddTagSheetView.swift
+++ b/GitSpace/Sources/Views/Home/AddTagSheetView.swift
@@ -89,7 +89,7 @@ struct AddTagSheetView: View {
                     print("Error-\(#file)-\(#function): Failed Optional unwrapping.")
                     return
                 }
-                await tagViewModel.addRepositoryTag(preSelectedTags, repositoryFullname: repository.fullName)
+                await tagViewModel.addRepositoryTag(preSelectedTags, to: repository.fullName)
             }
         case .starredView:
             if !preSelectedTags.isEmpty {

--- a/GitSpace/Sources/Views/Home/AddTagSheetView.swift
+++ b/GitSpace/Sources/Views/Home/AddTagSheetView.swift
@@ -19,6 +19,7 @@ struct AddTagSheetView: View {
     @EnvironmentObject var tagViewModel: TagViewModel
     @Binding var preSelectedTags: [Tag]
     @State var selectedTags: [Tag]
+    @State var deselectedTags: [Tag] = []
     @State private var tagInput: String = ""
     @StateObject private var keyboardHandler = KeyboardHandler()
     /// 어떤 뷰에서 AddTagSheetView를 호출했는지 확인합니다.
@@ -58,12 +59,24 @@ struct AddTagSheetView: View {
         }
     }
     
+    // MARK: Selection Tag Method
+    /// - Parameter tag: selected tag
+    /// - Description
+    /// 태그를 선택할 경우 발생하는 로직을 수행하는 메서드입니다.
+    /// 선택되지 않은 태그를 선택할 경우와 이미 선택된 태그를 선택할 경우로 분기처리된다.
     func selectTag(to tag: Tag) {
         if selectedTags.contains(tag) {
-            let selectedIndex: Int = selectedTags.firstIndex(of: tag)!
+            deselectedTags.append(tag)
+            guard let selectedIndex: Int = selectedTags.firstIndex(of: tag) else {
+                return
+            }
             selectedTags.remove(at: selectedIndex)
         } else {
             selectedTags.append(tag)
+            guard let deselectedIndex: Int = deselectedTags.firstIndex(of: tag) else {
+                return
+            }
+            deselectedTags.remove(at: deselectedIndex)
         }
     }
     

--- a/GitSpace/Sources/Views/Home/AddTagSheetView.swift
+++ b/GitSpace/Sources/Views/Home/AddTagSheetView.swift
@@ -24,7 +24,7 @@ struct AddTagSheetView: View {
     @StateObject private var keyboardHandler = KeyboardHandler()
     /// 어떤 뷰에서 AddTagSheetView를 호출했는지 확인합니다.
     var beforeView: BeforeView
-    let repositoryName: String?
+    let selectedRepository: Repository?
     
     let columns = [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())]
     
@@ -86,8 +86,8 @@ struct AddTagSheetView: View {
         case .repositoryDetailView:
             Task {
                 // FIXME: 실제 레포 이름 가져오기
-                guard let repositoryName = repositoryName else { return }
-                await tagViewModel.addRepositoryTag(preSelectedTags, repositoryFullname: repositoryName)
+                guard let repository = selectedRepository else { return }
+                await tagViewModel.addRepositoryTag(preSelectedTags, repositoryFullname: repository.fullName)
             }
         case .starredView:
             if !preSelectedTags.isEmpty {

--- a/GitSpace/Sources/Views/Home/RepositoryDetailView.swift
+++ b/GitSpace/Sources/Views/Home/RepositoryDetailView.swift
@@ -192,7 +192,7 @@ struct RepositoryDetailViewTags: View {
         // FIXME: selectedTag의 값
         /// 실제로는 각 레포가 가지고 있는 태그가 들어와야 한다!
         .fullScreenCover(isPresented: $isTagSheetShowed) {
-            AddTagSheetView(preSelectedTags: $selectedTags, selectedTags: selectedTags, beforeView: .repositoryDetailView, repositoryName: repository.fullName)
+            AddTagSheetView(preSelectedTags: $selectedTags, selectedTags: selectedTags, beforeView: .repositoryDetailView, selectedRepository: repository)
         }
         .onAppear {
             Task {

--- a/GitSpace/Sources/Views/Home/StarredView.swift
+++ b/GitSpace/Sources/Views/Home/StarredView.swift
@@ -230,7 +230,7 @@ struct StarredView: View {
             }
         }
         .sheet(isPresented: $isShowingSelectTagView) {
-            AddTagSheetView(preSelectedTags: $selectedTagList, selectedTags: selectedTagList, beforeView: .starredView, repositoryName: nil)
+            AddTagSheetView(preSelectedTags: $selectedTagList, selectedTags: selectedTagList, beforeView: .starredView, selectedRepository: nil)
         }
         .onTapGesture {
             self.endTextEditing()


### PR DESCRIPTION
## 개요 및 관련 이슈
- #259 작업 중 Tagging에서 삭제 기능이 없다는 것을 확인했다.
- 그래서 RepositoryDetailView에서 AddTagSheetView로 진입했을 때, Tag 삭제가 되도록 로직을 추가하였다.

## 작업 사항
- deleteRepositoryTag(_:)
- AddTagSheetView에서 진입한 뷰에 따라서 Done을 눌렀을 때 로직이 달라지도록 구현

## 주요 로직(Optional)
```swift
func selectTag(to tag: Tag) {
     if selectedTags.contains(tag) {
         let selectedIndex: Int = selectedTags.firstIndex(of: tag)!
         deselectedTags.append(tag)
         guard let selectedIndex: Int = selectedTags.firstIndex(of: tag) else {
             return
         }
         selectedTags.remove(at: selectedIndex)
     } else {
         selectedTags.append(tag)
         guard let deselectedIndex: Int = deselectedTags.firstIndex(of: tag) else {
             return
         }
         deselectedTags.remove(at: deselectedIndex)
     }
 }
```
