### PR TITLE
[Fix] #333 다른 사용자들의 Tag가 공유되는 Bug를 수정하였습니다.

### DIFF
--- a/GitSpace/Sources/ViewModels/TagViewModel.swift
+++ b/GitSpace/Sources/ViewModels/TagViewModel.swift
@@ -34,7 +34,7 @@ final class TagViewModel: ObservableObject {
                 self.tags.append( Tag(id: id, tagName: tagName, repositories: repositories) )
             }
         } catch {
-            print("Error")
+            print("Error-\(#file)-\(#function): \(error.localizedDescription)")
         }
     }
     
@@ -54,7 +54,7 @@ final class TagViewModel: ObservableObject {
                 ])
             return Tag(id: tid, tagName: tagName, repositories: [])
         } catch {
-            print("Register Tag Error")
+            print("Error-\(#file)-\(#function): \(error.localizedDescription)")
             return nil
         }
     }
@@ -69,7 +69,7 @@ final class TagViewModel: ObservableObject {
                 .document(tag.id)
                 .delete()
         } catch {
-            print("Delete Tag")
+            print("Error-\(#file)-\(#function): \(error.localizedDescription)")
         }
     }
     
@@ -99,7 +99,7 @@ final class TagViewModel: ObservableObject {
             }
             return tagNameList
         } catch {
-            print(error.localizedDescription)
+            print("Error-\(#file)-\(#function): \(error.localizedDescription)")
             return nil
         }
     }

--- a/GitSpace/Sources/ViewModels/TagViewModel.swift
+++ b/GitSpace/Sources/ViewModels/TagViewModel.swift
@@ -24,13 +24,13 @@ final class TagViewModel: ObservableObject {
         do {
             let snapshot = try await database.collection(const.COLLECTION_USER_INFO)
                 .document(Auth.auth().currentUser?.uid ?? "")
-                .collection("Tag")
+                .collection(const.COLLECTION_TAG)
                 .getDocuments()
             self.tags.removeAll()
             for document in snapshot.documents {
-                let id = document["id"] as? String ?? ""
-                let tagName = document["tagName"] as? String ?? ""
-                let repositories = document["repositories"] as? [String] ?? []
+                let id = document[const.FIELD_ID] as? String ?? ""
+                let tagName = document[const.FIELD_TAGNAME] as? String ?? ""
+                let repositories = document[const.FIELD_REPOSITORIES] as? [String] ?? []
                 self.tags.append( Tag(id: id, tagName: tagName, repositories: repositories) )
             }
         } catch {

--- a/GitSpace/Sources/ViewModels/TagViewModel.swift
+++ b/GitSpace/Sources/ViewModels/TagViewModel.swift
@@ -88,10 +88,6 @@ final class TagViewModel: ObservableObject {
     func requestRepositoryTags(repositoryName: String) async -> [Tag]? {
         do {
             var tagNameList: [Tag] = []
-//            let snapshot = try await database
-//                .collectionGroup(const.COLLECTION_TAG)
-//                .whereField(const.FIELD_REPOSITORIES, arrayContains: "\(repositoryName)")
-//                .getDocuments()
             let snapshot = try await database
                 .collection(const.COLLECTION_USER_INFO)
                 .document(Auth.auth().currentUser?.uid ?? "")

--- a/GitSpace/Sources/ViewModels/TagViewModel.swift
+++ b/GitSpace/Sources/ViewModels/TagViewModel.swift
@@ -45,12 +45,12 @@ final class TagViewModel: ObservableObject {
             let tid = UUID().uuidString
             try await database.collection(const.COLLECTION_USER_INFO)
                 .document(Auth.auth().currentUser?.uid ?? "")
-                .collection("Tag")
+                .collection(const.COLLECTION_TAG)
                 .document(tid)
                 .setData([
-                    "id": tid,
-                    "tagName": tagName,
-                    "repositories": []
+                    const.FIELD_ID: tid,
+                    const.FIELD_TAGNAME: tagName,
+                    const.FIELD_REPOSITORIES: []
                 ])
             return Tag(id: tid, tagName: tagName, repositories: [])
         } catch {
@@ -65,7 +65,7 @@ final class TagViewModel: ObservableObject {
         do {
             try await database.collection(const.COLLECTION_USER_INFO)
                 .document(Auth.auth().currentUser?.uid ?? "")
-                .collection("Tag")
+                .collection(const.COLLECTION_TAG)
                 .document(tag.id)
                 .delete()
         } catch {
@@ -88,13 +88,20 @@ final class TagViewModel: ObservableObject {
     func requestRepositoryTags(repositoryName: String) async -> [Tag]? {
         do {
             var tagNameList: [Tag] = []
-            let snapshot = try await database.collectionGroup("Tag")
-                .whereField("repositories", arrayContains: "\(repositoryName)")
+//            let snapshot = try await database
+//                .collectionGroup(const.COLLECTION_TAG)
+//                .whereField(const.FIELD_REPOSITORIES, arrayContains: "\(repositoryName)")
+//                .getDocuments()
+            let snapshot = try await database
+                .collection(const.COLLECTION_USER_INFO)
+                .document(Auth.auth().currentUser?.uid ?? "")
+                .collection(const.COLLECTION_TAG)
+                .whereField(const.FIELD_REPOSITORIES, arrayContains: "\(repositoryName)")
                 .getDocuments()
             for document in snapshot.documents {
-                let id = document.data()["id"] as? String ?? ""
-                let name = document.data()["tagName"] as? String ?? ""
-                let repositories = document.data()["repositories"] as? [String] ?? []
+                let id = document.data()[const.FIELD_ID] as? String ?? ""
+                let name = document.data()[const.FIELD_TAGNAME] as? String ?? ""
+                let repositories = document.data()[const.FIELD_REPOSITORIES] as? [String] ?? []
                 tagNameList.append(Tag(id: id, tagName: name, repositories: repositories))
             }
             return tagNameList

--- a/GitSpace/Utilities/Constant.swift
+++ b/GitSpace/Utilities/Constant.swift
@@ -48,6 +48,8 @@ public enum Constant {
         static let FIELD_BLOCKED_USER_IDS: String = "blockedUserIDs"
         
         static let COLLECTION_TAG: String = "Tag"
+        static let FIELD_ID: String = "id"
+        static let FIELD_TAGNAME: String = "tagName"
         static let FIELD_REPOSITORIES: String = "repositories"
     }
 	


### PR DESCRIPTION
## 개요 및 관련 이슈
- 특정 레포에서 Tagging이 안되는 Bug(#333)를 분석하다보니 다른 사용자들의 Tag가 공유되어서 생긴 문제임을 확인하였습니다.
- 원인은 Repository의 Tag를 불러오는 메서드 `requestRepositoryTags(_:)`에서 collectionGroup의 사용이었습니다.

## 작업 사항
- collectionGroup을 제거하고 일반 collection으로 변경
- UserInfo에서 Tag에 접근하도록 수정
- 오류 구문 컨벤션에 맞게 수정
- Const 적용

## 주요 로직(Optional)
```diff
let snapshot = try await database
-   .collectionGroup(const.COLLECTION_TAG)
+   .collection(const.COLLECTION_USER_INFO)
+   .document(Auth.auth().currentUser?.uid ?? "")
+   .collection(const.COLLECTION_TAG)
    .whereField(const.FIELD_REPOSITORIES, arrayContains: "\(repositoryName)")
    .getDocuments()
```
