### PR TITLE
Fix/#325 push notification wrong user name

### DIFF
--- a/GitSpace.xcodeproj/project.pbxproj
+++ b/GitSpace.xcodeproj/project.pbxproj
@@ -1072,6 +1072,7 @@
 /* Begin XCBuildConfiguration section */
 		7068B6B029769449005D6B7B /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6E19F1DA29C0CCDC0046BC31 /* Secrets.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
@@ -1133,6 +1134,7 @@
 		};
 		7068B6B129769449005D6B7B /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6E19F1DA29C0CCDC0046BC31 /* Secrets.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
@@ -1188,6 +1190,7 @@
 		};
 		7068B6B329769449005D6B7B /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6E19F1DA29C0CCDC0046BC31 /* Secrets.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -1226,6 +1229,7 @@
 		};
 		7068B6B429769449005D6B7B /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6E19F1DA29C0CCDC0046BC31 /* Secrets.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/GitSpace/Sources/Models/PushNotification/PushNotificationManager.swift
+++ b/GitSpace/Sources/Models/PushNotification/PushNotificationManager.swift
@@ -41,6 +41,14 @@ extension PushNotificationManager: GSPushNotificationSendable {
 		URL(string: "https://\(Constant.PushNotification.PUSH_NOTIFICATION_ENDPOINT)")
 	}
 	
+    /**
+     노티피케이션을 발송하는 메소드 입니다.
+     전해야 하는 메세지를 밖에서 전달하여 발송합니다.
+     - Parameters:
+        - with message: PushNotificationMessageType 으로 필요한 정보들을 전달하며, subtitle은 경우에 따라 생략할 수 있습니다.
+            - subtitle: 알람의 "발신자" 위치
+        - to userInfo: UserInfo
+     */
 	public func sendNotification(
 		with message: PushNotificationMessageType,
 		to userInfo: UserInfo
@@ -79,7 +87,7 @@ extension PushNotificationManager: GSPushNotificationSendable {
 			"notification": [
 				"title": pushNotificationBody.messageTitle,
 				"body": pushNotificationBody.messageBody,
-				"subtitle": pushNotificationBody.sentUserName,
+                "subtitle": pushNotificationBody.sentUserName != nil ? pushNotificationBody.sentUserName : "",
 				"badge": "1"
 			],
 			

--- a/GitSpace/Sources/Models/PushNotification/PushNotificationMessageBody.swift
+++ b/GitSpace/Sources/Models/PushNotification/PushNotificationMessageBody.swift
@@ -11,30 +11,37 @@ import Foundation
  Push Notification의 Payload 데이터 구조체.
  메세지의 제목, 바디, 발신자, 뷰가 도착해야 할 뷰, 도착하여 그려야 할 데이터의 정보를 담습니다.
  
+ - Properties:
+    - messageTitle: String
+    - messageBody: String
+    - sentUserName: String
+    - navigateTo: String
+    - viewBuildID: String
+    - knockPurpose: String?
  - Author: @Valselee
  */
 struct PushNotificationMessageBody {
 	let messageTitle: String
-	let messageBody: String
-	let sentUserName: String
+	let messageBody: String?
+	let sentUserName: String?
 	let navigateTo: String
 	let viewBuildID: String
     let knockPurpose: String?
 	
 	init(_ messageType: PushNotificationMessageType) {
 		switch messageType {
-		case let .knock(title, body, knockSentFrom, knockPurpose, knockID):
+		case let .knock(title, body, pushSentFrom, knockPurpose, knockID):
 			self.messageTitle = title
 			self.messageBody = body
 			self.navigateTo = "knock"
-			self.sentUserName = knockSentFrom
+			self.sentUserName = pushSentFrom
 			self.viewBuildID = knockID
             self.knockPurpose = knockPurpose
-		case let .chat(title, body, chatSentFrom, chatID):
+		case let .chat(title, body, pushSentFrom, chatID):
 			self.messageTitle = title
 			self.messageBody = body
 			self.navigateTo = "chat"
-			self.sentUserName = chatSentFrom
+			self.sentUserName = pushSentFrom
 			self.viewBuildID = chatID
             self.knockPurpose = nil
 		}
@@ -42,8 +49,8 @@ struct PushNotificationMessageBody {
 }
 
 enum PushNotificationMessageType {
-    case knock(title: String, body: String, knockSentFrom: String, knockPurpose: String, knockID: String)
-	case chat(title: String, body: String, chatSentFrom: String, chatID: String)
+    case knock(title: String, body: String? = nil, pushSentFrom: String? = nil, knockPurpose: String, knockID: String)
+    case chat(title: String, body: String? = nil, pushSentFrom: String, chatID: String)
 }
 
 struct GSPushNotification: Codable {

--- a/GitSpace/Sources/Views/Knock/MainKnockBox/EachKnockCell.swift
+++ b/GitSpace/Sources/Views/Knock/MainKnockBox/EachKnockCell.swift
@@ -14,6 +14,7 @@ struct EachKnockCell: View {
     @Binding var isEditing: Bool
     @State private var targetUserInfo: UserInfo? = nil
     @State private var isChecked: Bool = false
+    @State private var opacity: CGFloat = 0.4
     
     // MARK: Binding하면 상위 state에 의해 이름 잔상 애니메이션이 남는다.
     @State var userSelectedTab: String
@@ -33,10 +34,23 @@ struct EachKnockCell: View {
 						}
 				}
 				
-                GithubProfileImage(
-                    urlStr: targetUserInfo?.avatar_url ?? "",
-                    size: 50
-                )
+                if let targetUserInfo {
+                    GithubProfileImage(
+                        urlStr: targetUserInfo.avatar_url,
+                        size: 50
+                    )
+                } else {
+                    Image("ProfilePlaceholder")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .clipShape(Circle())
+                        .frame(width: 50)
+                        .modifier(BlinkingSkeletonModifier(
+                            opacity: opacity,
+                            shouldShow: true
+                        )
+                        )
+                }
 				
 				VStack {
 					HStack {
@@ -93,6 +107,11 @@ struct EachKnockCell: View {
 				.padding(.horizontal, 20)
 		}
         .task {
+            withAnimation(
+                .linear(duration: 0.5).repeatForever(autoreverses: true)
+            ) {
+                self.opacity = opacity == 0.4 ? 0.8 : 0.4
+            }
             // 노크 수신자 == 현재 유저일 경우, 노크 발신자의 정보를 타겟유저로 할당
             if eachKnock.receivedUserID == userInfoManager.currentUser?.id {
                 self.targetUserInfo = await userInfoManager.requestUserInfoWithID(userID: eachKnock.sentUserID)

--- a/GitSpace/Sources/Views/Knock/MainKnockBox/MainKnockView.swift
+++ b/GitSpace/Sources/Views/Knock/MainKnockBox/MainKnockView.swift
@@ -67,11 +67,18 @@ struct MainKnockView: View {
                     if userSelectedTab == Constant.KNOCK_RECEIVED {
                         Section {
                             if knockViewManager.receivedKnockList.isEmpty {
-                                Image("GitSpace-Knock-Empty")
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(width: 300, height: 300)
-                                    .transition(knockViewManager.leadingTransition)
+                                VStack {
+                                    Image("GitSpace-Knock-Empty")
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fit)
+                                        .frame(width: 300, height: 300)
+                                        .transition(knockViewManager.trailingTransition)
+                                    
+                                    GSText.CustomTextView(
+                                        style: .title1,
+                                        string: "There are no Knocks!")
+                                    .multilineTextAlignment(.center)
+                                }
                             } else {
                                 ForEach(
                                     $knockViewManager.receivedKnockList
@@ -141,11 +148,18 @@ struct MainKnockView: View {
                     } else if userSelectedTab == Constant.KNOCK_SENT {
                         Section {
                             if knockViewManager.sentKnockList.isEmpty {
-                                Image("GitSpace-Knock-Empty")
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(width: 300, height: 300)
-                                    .transition(knockViewManager.trailingTransition)
+                                VStack {
+                                    Image("GitSpace-Knock-Empty")
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fit)
+                                        .frame(width: 300, height: 300)
+                                        .transition(knockViewManager.trailingTransition)
+                                    
+                                    GSText.CustomTextView(
+                                        style: .title1,
+                                        string: "There are no Knocks!")
+                                    .multilineTextAlignment(.center)
+                                }
                             } else {
                                 ForEach($knockViewManager.sentKnockList
                                     .sorted {

--- a/GitSpace/Sources/Views/Knock/SendKnockView.swift
+++ b/GitSpace/Sources/Views/Knock/SendKnockView.swift
@@ -304,7 +304,7 @@ Please write a message carefully.
                                         with: .knock(
                                             title: "New Knock has been Arrived.",
                                             body: knockMessage,
-                                            knockSentFrom: userStore.currentUser?.githubLogin ?? "",
+                                            pushSentFrom: userStore.currentUser?.githubLogin ?? "",
                                             knockPurpose: chatPurpose,
                                             knockID: newKnock.id
                                         ),
@@ -404,7 +404,7 @@ Please write a message carefully.
                                         with: .knock(
                                             title: "New Knock has been Arrived.",
                                             body: knockMessage,
-                                            knockSentFrom: userStore.currentUser?.githubLogin ?? "",
+                                            pushSentFrom: userStore.currentUser?.githubLogin ?? "",
                                             knockPurpose: chatPurpose,
                                             knockID: newKnock.id
                                         ),


### PR DESCRIPTION
## 개요 및 관련 이슈
- #325 

## 작업 사항
- targetUserInfo 속성을 선언하여 수신자, 발신자가 더 명확히 구분되도록 시맨틱하게 리팩토링
- 노크 뷰 일부에 적용되어 있던 TopperView, GithubProfileImageView가 일으키던 에러 해걸
    - if let의 else 구문에 skeleton 적용 

## 주요 로직(Optional)
```swift
if let targetUserInfo {
  GithubProfileImage(
      urlStr: targetUserInfo.avatar_url,
      size: 50
  )
} else {
  Image("ProfilePlaceholder")
      .resizable()
      .aspectRatio(contentMode: .fit)
      .clipShape(Circle())
      .frame(width: 50)
      .modifier(BlinkingSkeletonModifier(
          opacity: opacity,
          shouldShow: true
      )
      )
}
```
