### PR TITLE
[BugFix] 채팅방을 입장해도 읽지 않은 메세지 갯수가 초기화되지 않는 현상을 해결했습니다.

### DIFF
--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -118,8 +118,12 @@ struct ChatRoomView: View {
             await messageStore.fetchMessages(chatID: chat.id, unreadMessageCount: unreadMessageCount)
             // 유저가 읽지 않은 메세지의 시작 인덱스를 계산해서 할당
             unreadMessageIndex = messageStore.messages.count - unreadMessageCount
-            // 읽지 않은 메세지 갯수를 0으로 초기화
-            await clearUnreadMessageCount()
+            
+            // 읽지 않은 메세지가 있으면
+            if unreadMessageCount > 0 {
+                // 읽지 않은 메세지 갯수를 0으로 초기화
+                await clearUnreadMessageCount()
+            }
         }
         // MessageCell ContextMenu에서 삭제 버튼을 탭하면 수행되는 로직
         .onChange(of: messageStore.deletedMessage?.id) { id in

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -21,6 +21,7 @@ struct ChatRoomView: View {
 
     let chat: Chat
     let targetUserInfo: UserInfo
+    
     @Environment(\.scenePhase) var scenePhase
     @EnvironmentObject var chatStore: ChatStore
     @EnvironmentObject var messageStore: MessageStore
@@ -350,9 +351,7 @@ struct ChatRoomView: View {
         // 채팅방 입장 시, 내가 안 읽은 메세지 갯수를 0으로 초기화하는 케이스
         case .enterOrQuitChatRoom:
             var newDict: [String : Int] = chat.unreadMessageCount
-            if let uid = userStore.user?.id {
-                newDict[uid] = 0
-            }
+            newDict[Utility.loginUserID] = 0
             newChat.unreadMessageCount = newDict
         }
         return newChat

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -148,7 +148,10 @@ struct ChatRoomView: View {
         // 채팅방에서 벗어날 때 수행되는 로직
         .onDisappear {
             Task {
-                await clearUnreadMessageCount()
+                let currentMessageIDs: [String] = messageStore.messages.map{$0.id}
+                if currentMessageIDs != preMessageIDs {
+                    await clearUnreadMessageCount()
+                }
                 messageStore.removeListener()
             }
         }

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -349,6 +349,7 @@ struct ChatRoomView: View {
         
         // 채팅방 입장 시, 내가 안 읽은 메세지 갯수를 0으로 초기화하는 케이스
         case .enterOrQuitChatRoom:
+            // FIXME: userStore.user? 대신에 Utility.loginUserID를 사용하면 해결은 됨, 근데 앱 실행 시 writeUser가 잘 되었는데 채팅방 안에서만 user?가 nil인 이유를 찾아봐야함
             var newDict: [String : Int] = chat.unreadMessageCount
             if let uid = userStore.user?.id {
                 newDict[uid] = 0

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -148,8 +148,6 @@ struct ChatRoomView: View {
                 await clearUnreadMessageCount()
                 messageStore.removeListener()
             }
-            
-//            tabBarRouter.navigateToChat = false
         }
     }
     

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -119,6 +119,8 @@ struct ChatRoomView: View {
             await messageStore.fetchMessages(chatID: chat.id, unreadMessageCount: unreadMessageCount)
             // 유저가 읽지 않은 메세지의 시작 인덱스를 계산해서 할당
             unreadMessageIndex = messageStore.messages.count - unreadMessageCount
+            // 채팅방 입장 기준으로 메세지들의 ID를 저장 (disAppear 시 체크하는 용도로 사용)
+            preMessageIDs = messageStore.messages.map{$0.id}
             
             // 읽지 않은 메세지가 있으면
             if unreadMessageCount > 0 {

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -133,6 +133,7 @@ struct ChatRoomView: View {
                 }
             }
         }
+        // 유저가 앱 화면에서 벗어났을 때 수행되는 로직
         .onChange(of: scenePhase) { currentPhase in
             // FIXME: inActive 혹은 backGround에 가는 것을 채팅방을 나가는것처럼 처리해줄지, 돌아올 때 채팅방에 입장한 것처럼 처리해줄지 고려 필요. By 태영
             if currentPhase == .inactive {
@@ -141,6 +142,7 @@ struct ChatRoomView: View {
                 }
             }
         }
+        // 채팅방에서 벗어날 때 수행되는 로직
         .onDisappear {
             Task {
                 await clearUnreadMessageCount()

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -265,7 +265,7 @@ struct ChatRoomView: View {
                                          chatID: chat.id)
     }
     
-    // MARK: Method - 상대방이 안 읽은 메세지 갯수를 반환하는 함수
+    // MARK: Method - 내가 읽지않은 메세지 갯수를 반환하는 함수
     private func getUnreadCount() async -> Int {
         let dict = await chatStore.getUnreadMessageDictionary(chatID: chat.id)
         let unreadCount = dict?[Utility.loginUserID] ?? 0

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -30,6 +30,7 @@ struct ChatRoomView: View {
     @StateObject private var keyboardHandler = KeyboardHandler()
     @State private var contentField: String = ""
     @State private var unreadMessageIndex: Int?
+    @State private var preMessageIDs: [String] = []
     
     
     var body: some View {

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -349,7 +349,6 @@ struct ChatRoomView: View {
         
         // 채팅방 입장 시, 내가 안 읽은 메세지 갯수를 0으로 초기화하는 케이스
         case .enterOrQuitChatRoom:
-            // FIXME: userStore.user? 대신에 Utility.loginUserID를 사용하면 해결은 됨, 근데 앱 실행 시 writeUser가 잘 되었는데 채팅방 안에서만 user?가 nil인 이유를 찾아봐야함
             var newDict: [String : Int] = chat.unreadMessageCount
             if let uid = userStore.user?.id {
                 newDict[uid] = 0


### PR DESCRIPTION
## 개요 및 관련 이슈
- #326 

## 작업 사항
- 버그가 발생 원인 확인
- 버그 로직 수정
- 사용자 기기 두 개로 작동 테스트
- 채팅방 진입 시, 읽지 않은 메세지가 0개인 경우 clearUnreadMessageCount를 호출하지 않도록 조건 추가
- 채팅방 퇴장 시, 추가로 생성된 메세지가 없으면 clearUnreadMessageCount를 호출하지 않도록 조건 추가

## 주요 로직(Optional)
```diff
- if let uid = userStore.user?.id {
-                newDict[uid] = 0
-            }
+ newDict[Utility.loginUserID] = 0
```
