### PR TITLE
[Feat] #327 TargetUser의 Following과 Followers List를 호출하는 함수를 구현하고 적용합니다.

### DIFF
--- a/GitSpace.xcodeproj/project.pbxproj
+++ b/GitSpace.xcodeproj/project.pbxproj
@@ -40,7 +40,6 @@
 		22958CAD29C752B000786357 /* ReadmeLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22958CAB29C752AF00786357 /* ReadmeLoadingView.swift */; };
 		22958CAE29C752B000786357 /* FailToLoadReadmeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22958CAC29C752AF00786357 /* FailToLoadReadmeView.swift */; };
 		22958CB029C7548100786357 /* TargetUserProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22958CAF29C7548000786357 /* TargetUserProfileViewModel.swift */; };
-		22958CB229C75BE400786357 /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 22958CB129C75BE400786357 /* Secrets.xcconfig */; };
 		22B1F2A6299231B60010FD15 /* NotificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22B1F2A5299231B60010FD15 /* NotificationView.swift */; };
 		22B1F2A8299235460010FD15 /* SystemNotificationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22B1F2A7299235460010FD15 /* SystemNotificationCell.swift */; };
 		22B1F2AA299235520010FD15 /* KnockNotificationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22B1F2A9299235520010FD15 /* KnockNotificationCell.swift */; };
@@ -82,6 +81,7 @@
 		348540F7299D5F8600B738F9 /* AfterReportGuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348540F6299D5F8600B738F9 /* AfterReportGuideView.swift */; };
 		348540F9299DDC5500B738F9 /* TermsOfServiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348540F8299DDC5500B738F9 /* TermsOfServiceView.swift */; };
 		348AB2B829ACE5C200F2D465 /* ContributorListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348AB2B729ACE5C200F2D465 /* ContributorListCell.swift */; };
+		34BF6A6629C8ABBE00D15DFE /* TargetUserFollowingListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BF6A6529C8ABBE00D15DFE /* TargetUserFollowingListView.swift */; };
 		34F44F2829B9E32500A5D5A1 /* ContributorListSkeletonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F44F2729B9E32500A5D5A1 /* ContributorListSkeletonView.swift */; };
 		680C199F29937CAD009AF5D5 /* SigninView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 680C199E29937CAD009AF5D5 /* SigninView.swift */; };
 		680C19A1299385A2009AF5D5 /* InitialView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 680C19A0299385A2009AF5D5 /* InitialView.swift */; };
@@ -203,7 +203,6 @@
 		22958CAB29C752AF00786357 /* ReadmeLoadingView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadmeLoadingView.swift; sourceTree = "<group>"; };
 		22958CAC29C752AF00786357 /* FailToLoadReadmeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FailToLoadReadmeView.swift; sourceTree = "<group>"; };
 		22958CAF29C7548000786357 /* TargetUserProfileViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TargetUserProfileViewModel.swift; sourceTree = "<group>"; };
-		22958CB129C75BE400786357 /* Secrets.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		22B1F2A5299231B60010FD15 /* NotificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationView.swift; sourceTree = "<group>"; };
 		22B1F2A7299235460010FD15 /* SystemNotificationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemNotificationCell.swift; sourceTree = "<group>"; };
 		22B1F2A9299235520010FD15 /* KnockNotificationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnockNotificationCell.swift; sourceTree = "<group>"; };
@@ -248,6 +247,7 @@
 		348AB2B729ACE5C200F2D465 /* ContributorListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContributorListCell.swift; sourceTree = "<group>"; };
 		34BC356E29779201000DCBC7 /* EachKnockCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EachKnockCell.swift; sourceTree = "<group>"; };
 		34BC357D2988EA4D000DCBC7 /* SendKnockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendKnockView.swift; sourceTree = "<group>"; };
+		34BF6A6529C8ABBE00D15DFE /* TargetUserFollowingListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetUserFollowingListView.swift; sourceTree = "<group>"; };
 		34F44F2729B9E32500A5D5A1 /* ContributorListSkeletonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContributorListSkeletonView.swift; sourceTree = "<group>"; };
 		680C199E29937CAD009AF5D5 /* SigninView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SigninView.swift; sourceTree = "<group>"; };
 		680C19A0299385A2009AF5D5 /* InitialView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialView.swift; sourceTree = "<group>"; };
@@ -725,6 +725,7 @@
 				22958CA929C7529600786357 /* TargetUserProfileView.swift */,
 				22958CA729C7528400786357 /* CurrentUserProfileView.swift */,
 				7068B6C12976952B005D6B7B /* MainProfileView.swift */,
+				34BF6A6529C8ABBE00D15DFE /* TargetUserFollowingListView.swift */,
 			);
 			path = Profile;
 			sourceTree = "<group>";
@@ -981,6 +982,7 @@
 				225A22D1299778A900786B35 /* HTTPClient.swift in Sources */,
 				34277363299495EC00818816 /* SetPrivacySafetyView.swift in Sources */,
 				342773572993E1BE00818816 /* SetLicensesView.swift in Sources */,
+				34BF6A6629C8ABBE00D15DFE /* TargetUserFollowingListView.swift in Sources */,
 				70ABF2C7298C07F90058467E /* View+DesignSystem.swift in Sources */,
 				34277361299495C000818816 /* SetAccountView.swift in Sources */,
 				2205F243299D1B0B00B2643D /* EventViewModel.swift in Sources */,

--- a/GitSpace.xcodeproj/project.pbxproj
+++ b/GitSpace.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		348540F9299DDC5500B738F9 /* TermsOfServiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348540F8299DDC5500B738F9 /* TermsOfServiceView.swift */; };
 		348AB2B829ACE5C200F2D465 /* ContributorListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348AB2B729ACE5C200F2D465 /* ContributorListCell.swift */; };
 		34BF6A6629C8ABBE00D15DFE /* TargetUserFollowingListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BF6A6529C8ABBE00D15DFE /* TargetUserFollowingListView.swift */; };
+		34BF6A6829C9F04700D15DFE /* FollowingResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BF6A6729C9F04700D15DFE /* FollowingResponse.swift */; };
 		34F44F2829B9E32500A5D5A1 /* ContributorListSkeletonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F44F2729B9E32500A5D5A1 /* ContributorListSkeletonView.swift */; };
 		680C199F29937CAD009AF5D5 /* SigninView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 680C199E29937CAD009AF5D5 /* SigninView.swift */; };
 		680C19A1299385A2009AF5D5 /* InitialView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 680C19A0299385A2009AF5D5 /* InitialView.swift */; };
@@ -248,6 +249,7 @@
 		34BC356E29779201000DCBC7 /* EachKnockCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EachKnockCell.swift; sourceTree = "<group>"; };
 		34BC357D2988EA4D000DCBC7 /* SendKnockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendKnockView.swift; sourceTree = "<group>"; };
 		34BF6A6529C8ABBE00D15DFE /* TargetUserFollowingListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetUserFollowingListView.swift; sourceTree = "<group>"; };
+		34BF6A6729C9F04700D15DFE /* FollowingResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowingResponse.swift; sourceTree = "<group>"; };
 		34F44F2729B9E32500A5D5A1 /* ContributorListSkeletonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContributorListSkeletonView.swift; sourceTree = "<group>"; };
 		680C199E29937CAD009AF5D5 /* SigninView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SigninView.swift; sourceTree = "<group>"; };
 		680C19A0299385A2009AF5D5 /* InitialView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialView.swift; sourceTree = "<group>"; };
@@ -380,6 +382,7 @@
 				2204BD4E299B1BD200AA4725 /* ContributorProfile.swift */,
 				22E9ECF2299BB92100D5A9C6 /* Owner.swift */,
 				2205F23E299CC04400B2643D /* FollowerResponse.swift */,
+				34BF6A6729C9F04700D15DFE /* FollowingResponse.swift */,
 				2205F23C299C9F1400B2643D /* Event.swift */,
 			);
 			path = APIModels;
@@ -1007,6 +1010,7 @@
 				6E38C6042991EF380043A8BB /* ChatListCell.swift in Sources */,
 				680C944529B9F2A300720718 /* KeyChainManager.swift in Sources */,
 				347146022990BC5200ED990C /* TopperProfileView.swift in Sources */,
+				34BF6A6829C9F04700D15DFE /* FollowingResponse.swift in Sources */,
 				6E000CB7298A67E800446C0D /* GithubProfileImage.swift in Sources */,
 				7068B6A829769448005D6B7B /* GitSpaceApp.swift in Sources */,
 				70BB6CE0299B105B009948FC /* URL+DeepLink.swift in Sources */,

--- a/GitSpace.xcodeproj/project.pbxproj
+++ b/GitSpace.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		348AB2B829ACE5C200F2D465 /* ContributorListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348AB2B729ACE5C200F2D465 /* ContributorListCell.swift */; };
 		34BF6A6629C8ABBE00D15DFE /* TargetUserFollowingListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BF6A6529C8ABBE00D15DFE /* TargetUserFollowingListView.swift */; };
 		34BF6A6829C9F04700D15DFE /* FollowingResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BF6A6729C9F04700D15DFE /* FollowingResponse.swift */; };
+		34BF6A6A29CA0A4600D15DFE /* FollowingSkeletonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BF6A6929CA0A4600D15DFE /* FollowingSkeletonView.swift */; };
 		34F44F2829B9E32500A5D5A1 /* ContributorListSkeletonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F44F2729B9E32500A5D5A1 /* ContributorListSkeletonView.swift */; };
 		680C199F29937CAD009AF5D5 /* SigninView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 680C199E29937CAD009AF5D5 /* SigninView.swift */; };
 		680C19A1299385A2009AF5D5 /* InitialView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 680C19A0299385A2009AF5D5 /* InitialView.swift */; };
@@ -250,6 +251,7 @@
 		34BC357D2988EA4D000DCBC7 /* SendKnockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendKnockView.swift; sourceTree = "<group>"; };
 		34BF6A6529C8ABBE00D15DFE /* TargetUserFollowingListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetUserFollowingListView.swift; sourceTree = "<group>"; };
 		34BF6A6729C9F04700D15DFE /* FollowingResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowingResponse.swift; sourceTree = "<group>"; };
+		34BF6A6929CA0A4600D15DFE /* FollowingSkeletonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowingSkeletonView.swift; sourceTree = "<group>"; };
 		34F44F2729B9E32500A5D5A1 /* ContributorListSkeletonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContributorListSkeletonView.swift; sourceTree = "<group>"; };
 		680C199E29937CAD009AF5D5 /* SigninView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SigninView.swift; sourceTree = "<group>"; };
 		680C19A0299385A2009AF5D5 /* InitialView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialView.swift; sourceTree = "<group>"; };
@@ -729,6 +731,7 @@
 				22958CA729C7528400786357 /* CurrentUserProfileView.swift */,
 				7068B6C12976952B005D6B7B /* MainProfileView.swift */,
 				34BF6A6529C8ABBE00D15DFE /* TargetUserFollowingListView.swift */,
+				34BF6A6929CA0A4600D15DFE /* FollowingSkeletonView.swift */,
 			);
 			path = Profile;
 			sourceTree = "<group>";
@@ -1042,6 +1045,7 @@
 				6EC383A5298FE49000F209CF /* UIFont+.swift in Sources */,
 				34582163298A4A310058CA4C /* KeyboardHandler.swift in Sources */,
 				68D76D4C298712EC00C1EA88 /* GitHubAuthManager.swift in Sources */,
+				34BF6A6A29CA0A4600D15DFE /* FollowingSkeletonView.swift in Sources */,
 				348540F1299D5E7700B738F9 /* BlockListGuideView.swift in Sources */,
 				687AE54E298FA1E800113ABF /* RepositoryViewModel.swift in Sources */,
 				22958CB029C7548100786357 /* TargetUserProfileViewModel.swift in Sources */,

--- a/GitSpace/GitSpaceApp.swift
+++ b/GitSpace/GitSpaceApp.swift
@@ -27,6 +27,8 @@ struct GitSpaceApp: App {
                 .environmentObject(TagViewModel())
                 .environmentObject(GitHubAuthManager())
                 .environmentObject(KnockViewManager())
+                .environmentObject(FollowingViewModel(service: GitHubService()))
+                .environmentObject(FollowerViewModel(service: GitHubService()))
                 .environmentObject(tabBarRouter)
 				.environmentObject(pushNotificationManager)
 				.onAppear {

--- a/GitSpace/Sources/Network/APIModels/FollowingResponse.swift
+++ b/GitSpace/Sources/Network/APIModels/FollowingResponse.swift
@@ -5,5 +5,39 @@
 //  Created by 최한호 on 2023/03/21.
 //
 
-import SwiftUI
+import Foundation
 
+struct FollowingResponse: Codable {
+    let login: String
+    let id: Int
+    let nodeID: String
+    let avatarURL: String
+    let gravatarID: String
+    let url, htmlURL, followersURL: String
+    let followingURL, gistsURL, starredURL: String
+    let subscriptionsURL, organizationsURL, reposURL: String
+    let eventsURL: String
+    let receivedEventsURL: String
+    let type: String
+    let siteAdmin: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case login, id
+        case nodeID = "node_id"
+        case avatarURL = "avatar_url"
+        case gravatarID = "gravatar_id"
+        case url
+        case htmlURL = "html_url"
+        case followersURL = "followers_url"
+        case followingURL = "following_url"
+        case gistsURL = "gists_url"
+        case starredURL = "starred_url"
+        case subscriptionsURL = "subscriptions_url"
+        case organizationsURL = "organizations_url"
+        case reposURL = "repos_url"
+        case eventsURL = "events_url"
+        case receivedEventsURL = "received_events_url"
+        case type
+        case siteAdmin = "site_admin"
+    }
+}

--- a/GitSpace/Sources/Network/APIModels/FollowingResponse.swift
+++ b/GitSpace/Sources/Network/APIModels/FollowingResponse.swift
@@ -1,0 +1,9 @@
+//
+//  FollowingResponse.swift
+//  GitSpace
+//
+//  Created by 최한호 on 2023/03/21.
+//
+
+import SwiftUI
+

--- a/GitSpace/Sources/Network/Endpoints/GitHubAPIEndpoint.swift
+++ b/GitSpace/Sources/Network/Endpoints/GitHubAPIEndpoint.swift
@@ -110,6 +110,10 @@ extension GitHubAPIEndpoint: Endpoint {
             return .put
         case .unfollowUser:
             return .delete
+        case .userFollowingList:
+            return .get
+        case .userFollowerList:
+            return .get
         }
     }
 

--- a/GitSpace/Sources/Network/Endpoints/GitHubAPIEndpoint.swift
+++ b/GitSpace/Sources/Network/Endpoints/GitHubAPIEndpoint.swift
@@ -153,7 +153,7 @@ extension GitHubAPIEndpoint: Endpoint {
         case .authenticatedUserRepositories(let page):
             return [URLQueryItem(name: "page", value: "\(page)")]
             
-        case .authenticatedUserReceivedEvents( _ , let page):
+        case .authenticatedUserReceivedEvents(_, let page):
             return [URLQueryItem(name: "page", value: "\(page)")]
         
         // defualt는 한 페이지당 30명의 contributor이며, pagenation을 위해 page를 연관값으로 가짐
@@ -164,6 +164,14 @@ extension GitHubAPIEndpoint: Endpoint {
             return [URLQueryItem(name: "page", value: "\(page)")]
 
         case .authenticatedUserFollowers(let perPage, let page):
+            return [URLQueryItem(name: "page", value: "\(page)"), URLQueryItem(name: "per_page", value: "\(perPage)")]
+        
+        // default는 한 페이지당 30명의 Following User이며, pagenation을 위해 page를 연관값으로 가짐
+        case .userFollowingList(_, let perPage, let page):
+            return [URLQueryItem(name: "page", value: "\(page)"), URLQueryItem(name: "per_page", value: "\(perPage)")]
+        
+        // default는 한 페이지당 30명의 Follower이며, pagenation을 위해 page를 연관값으로 가짐
+        case .userFollowerList(_, let perPage, let page):
             return [URLQueryItem(name: "page", value: "\(page)"), URLQueryItem(name: "per_page", value: "\(perPage)")]
             
         default:

--- a/GitSpace/Sources/Network/Endpoints/GitHubAPIEndpoint.swift
+++ b/GitSpace/Sources/Network/Endpoints/GitHubAPIEndpoint.swift
@@ -19,6 +19,8 @@ enum GitHubAPIEndpoint {
     case authenticatedUserFollowsPerson(userName: String)
     case userInformation(userName: String)
     case userStarRepositories(userName: String, page: Int)
+    case userFollowingList(userName: String, perPage: Int, page: Int)
+    case userFollowerList(userName: String, perPage: Int, page: Int)
     case repositoryInformation(owner: String, repositoryName: String)
     case repositoryREADME(owner: String, repositoryName: String)
     case markdownToHTML(markdownString: String)

--- a/GitSpace/Sources/Network/Endpoints/GitHubAPIEndpoint.swift
+++ b/GitSpace/Sources/Network/Endpoints/GitHubAPIEndpoint.swift
@@ -67,6 +67,11 @@ extension GitHubAPIEndpoint: Endpoint {
             return "/user/following/\(userName)"
         case .unfollowUser(let userName):
             return "/user/following/\(userName)"
+        case .userFollowingList(let userName, _, _ ):
+            return "/users/\(userName)/following"
+        case .userFollowerList(let userName, _, _ ):
+            return "/users/\(userName)/followers"
+            
         }
         
     }

--- a/GitSpace/Sources/Network/Services/GitHubService.swift
+++ b/GitSpace/Sources/Network/Services/GitHubService.swift
@@ -52,6 +52,9 @@ protocol GitHubServiceProtocol {
     /// 특정 유저의 Following List를 요청하는 함수
     func requestUserFollowingList(userName: String, perPage: Int, page: Int) async -> Result<[UserResponse], GitHubAPIError>
     
+    /// 특정 유저의 Follower List를 요청하는 함수
+    func requestUserFollowerList(userName: String, perPage: Int, page: Int) async -> Result<[UserResponse], GitHubAPIError>
+    
     /// 특정 레포지토리의 정보를 요청하는 함수
     func requestRepositoryInformation(owner: String, repositoryName: String) async -> Result<Repository, GitHubAPIError>
     

--- a/GitSpace/Sources/Network/Services/GitHubService.swift
+++ b/GitSpace/Sources/Network/Services/GitHubService.swift
@@ -206,6 +206,19 @@ struct GitHubService: HTTPClient, GitHubServiceProtocol {
     }
     
     /**
+     특정 유저의 Following List 정보를 요청합니다.
+     - Author: 한호
+     - parameters:
+        - userName: GitHub userName
+        - perPage: page 당 요청할 개수(default: 30, max: 100)
+        - page: 요청할 page numbe
+     - returns: 요청 성공시 특정 유저의 Follower 목록을, 요청 실패시 GitHubAPIError를 가지는 Result 타입을 리턴합니다.
+     */
+    func requestUserFollowerList(userName: String, perPage: Int, page: Int) async -> Result<[UserResponse], GitHubAPIError> {
+        return await sendRequest(endpoint: GitHubAPIEndpoint.userFollowerList(userName: userName, perPage: perPage, page: page), responseModel: [UserResponse].self)
+    }
+    
+    /**
      특정 레포지토리의 정보를 요청합니다.
      - Author: 제균
      - parameters:

--- a/GitSpace/Sources/Network/Services/GitHubService.swift
+++ b/GitSpace/Sources/Network/Services/GitHubService.swift
@@ -50,10 +50,10 @@ protocol GitHubServiceProtocol {
     func requestUserStarRepositories(userName: String, page: Int) async -> Result<[RepositoryResponse], GitHubAPIError>
     
     /// 특정 유저의 Following List를 요청하는 함수
-    func requestUserFollowingList(userName: String, perPage: Int, page: Int) async -> Result<[UserResponse], GitHubAPIError>
+    func requestUserFollowingList(userName: String, perPage: Int, page: Int) async -> Result<[FollowingResponse], GitHubAPIError>
     
     /// 특정 유저의 Follower List를 요청하는 함수
-    func requestUserFollowerList(userName: String, perPage: Int, page: Int) async -> Result<[UserResponse], GitHubAPIError>
+    func requestUserFollowerList(userName: String, perPage: Int, page: Int) async -> Result<[FollowingResponse], GitHubAPIError>
     
     /// 특정 레포지토리의 정보를 요청하는 함수
     func requestRepositoryInformation(owner: String, repositoryName: String) async -> Result<Repository, GitHubAPIError>
@@ -207,8 +207,8 @@ struct GitHubService: HTTPClient, GitHubServiceProtocol {
         - page: 요청할 page number
      - returns: 요청 성공시 특정 유저의 Following 목록을, 요청 실패시 GitHubAPIError를 가지는 Result 타입을 리턴합니다.
      */
-    func requestUserFollowingList(userName: String, perPage: Int, page: Int) async -> Result<[UserResponse], GitHubAPIError> {
-        return await sendRequest(endpoint: GitHubAPIEndpoint.userFollowingList(userName: userName, perPage: perPage, page: page), responseModel: [UserResponse].self)
+    func requestUserFollowingList(userName: String, perPage: Int, page: Int) async -> Result<[FollowingResponse], GitHubAPIError> {
+        return await sendRequest(endpoint: GitHubAPIEndpoint.userFollowingList(userName: userName, perPage: perPage, page: page), responseModel: [FollowingResponse].self)
     }
     
     /**
@@ -220,8 +220,8 @@ struct GitHubService: HTTPClient, GitHubServiceProtocol {
         - page: 요청할 page numbe
      - returns: 요청 성공시 특정 유저의 Follower 목록을, 요청 실패시 GitHubAPIError를 가지는 Result 타입을 리턴합니다.
      */
-    func requestUserFollowerList(userName: String, perPage: Int, page: Int) async -> Result<[UserResponse], GitHubAPIError> {
-        return await sendRequest(endpoint: GitHubAPIEndpoint.userFollowerList(userName: userName, perPage: perPage, page: page), responseModel: [UserResponse].self)
+    func requestUserFollowerList(userName: String, perPage: Int, page: Int) async -> Result<[FollowingResponse], GitHubAPIError> {
+        return await sendRequest(endpoint: GitHubAPIEndpoint.userFollowerList(userName: userName, perPage: perPage, page: page), responseModel: [FollowingResponse].self)
     }
     
     /**

--- a/GitSpace/Sources/Network/Services/GitHubService.swift
+++ b/GitSpace/Sources/Network/Services/GitHubService.swift
@@ -49,6 +49,9 @@ protocol GitHubServiceProtocol {
     /// 특정 유저의 starred repository들을 요청하는 함수
     func requestUserStarRepositories(userName: String, page: Int) async -> Result<[RepositoryResponse], GitHubAPIError>
     
+    /// 특정 유저의 Following List를 요청하는 함수
+    func requestUserFollowingList(userName: String, perPage: Int, page: Int) async -> Result<[UserResponse], GitHubAPIError>
+    
     /// 특정 레포지토리의 정보를 요청하는 함수
     func requestRepositoryInformation(owner: String, repositoryName: String) async -> Result<Repository, GitHubAPIError>
     

--- a/GitSpace/Sources/Network/Services/GitHubService.swift
+++ b/GitSpace/Sources/Network/Services/GitHubService.swift
@@ -212,7 +212,7 @@ struct GitHubService: HTTPClient, GitHubServiceProtocol {
     }
     
     /**
-     특정 유저의 Following List 정보를 요청합니다.
+     특정 유저의 Follower List 정보를 요청합니다.
      - Author: 한호
      - parameters:
         - userName: GitHub userName
@@ -271,10 +271,5 @@ struct GitHubService: HTTPClient, GitHubServiceProtocol {
     func requestRepositoryContributors(owner: String, repositoryName: String, page: Int) async -> Result<[ContributorProfile], GitHubAPIError> {
         return await sendRequest(endpoint: GitHubAPIEndpoint.repositoryContributors(owner: owner, repositoryName: repositoryName, page: page), responseModel: [ContributorProfile].self)
     }
-    
-    
-    
-    
-    
     
 }

--- a/GitSpace/Sources/Network/Services/GitHubService.swift
+++ b/GitSpace/Sources/Network/Services/GitHubService.swift
@@ -188,9 +188,21 @@ struct GitHubService: HTTPClient, GitHubServiceProtocol {
         - page: 요청할 page number
      - returns: 요청 성공시 특정 유저가 star를 눌러둔 레포지토리 목록을, 요청 실패시 GitHubAPIError를 가지는 Result 타입을 리턴합니다.
      */
-    
     func requestUserStarRepositories(userName: String, page: Int) async -> Result<[RepositoryResponse], GitHubAPIError> {
         return await sendRequest(endpoint: GitHubAPIEndpoint.userStarRepositories(userName: userName, page: page), responseModel: [RepositoryResponse].self)
+    }
+    
+    /**
+     특정 유저의 Following List 정보를 요청합니다.
+     - Author: 한호
+     - parameters:
+        - userName: GitHub userName
+        - perPage: page 당 요청할 개수(default: 30, max: 100)
+        - page: 요청할 page number
+     - returns: 요청 성공시 특정 유저의 Following 목록을, 요청 실패시 GitHubAPIError를 가지는 Result 타입을 리턴합니다.
+     */
+    func requestUserFollowingList(userName: String, perPage: Int, page: Int) async -> Result<[UserResponse], GitHubAPIError> {
+        return await sendRequest(endpoint: GitHubAPIEndpoint.userFollowingList(userName: userName, perPage: perPage, page: page), responseModel: [UserResponse].self)
     }
     
     /**

--- a/GitSpace/Sources/ViewModels/FollowerViewModel.swift
+++ b/GitSpace/Sources/ViewModels/FollowerViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 final class FollowerViewModel: ObservableObject {
     @Published var responses: [FollowerResponse] = []
@@ -21,6 +22,51 @@ final class FollowerViewModel: ObservableObject {
             case .failure(let error):
                 print(error)
             }
+        }
+    }
+}
+
+final class FollowingViewModel: ObservableObject {
+    
+    private let service: GitHubService
+    
+    init(service: GitHubService) {
+        self.service = service
+    }
+    
+    @Published var followings: [GithubUser] = []
+    @Published var isLoading: Bool = true
+    var temporaryFollowings: [GithubUser] = []
+    
+    public func getFollowing(with userID: Int) -> GithubUser? {
+        let result = followings.filter { $0.id == userID }.first
+        print(#file, #function, result?.name ?? "FAILED: getFollowing")
+        return result
+    }
+    
+    @MainActor
+    func requestFollowings(user: GithubUser, perPage: Int, page: Int) async -> Result<Void, GitHubAPIError> {
+        
+        let followingsResult = await service.requestUserFollowerList(userName: user.login, perPage: perPage, page: page)
+        
+        switch followingsResult {
+        case .success(let users):
+            for user in users {
+                let result = await service.requestUserInformation(userName: user.login)
+                
+                switch result {
+                case .success(let user):
+                    temporaryFollowings.append(user)
+                case .failure(let error):
+                    return .failure(error)
+                }
+            }
+            withAnimation(.easeInOut) {
+                self.isLoading = false
+            }
+            return .success(())
+        case .failure(let error):
+            return .failure(error)
         }
     }
 }

--- a/GitSpace/Sources/ViewModels/FollowerViewModel.swift
+++ b/GitSpace/Sources/ViewModels/FollowerViewModel.swift
@@ -47,7 +47,7 @@ final class FollowingViewModel: ObservableObject {
     @MainActor
     func requestFollowings(user: GithubUser, perPage: Int, page: Int) async -> Result<Void, GitHubAPIError> {
         
-        let followingsResult = await service.requestUserFollowerList(userName: user.login, perPage: perPage, page: page)
+        let followingsResult = await service.requestUserFollowingList(userName: user, perPage: perPage, page: page)
         
         switch followingsResult {
         case .success(let users):

--- a/GitSpace/Sources/ViewModels/FollowerViewModel.swift
+++ b/GitSpace/Sources/ViewModels/FollowerViewModel.swift
@@ -45,7 +45,7 @@ final class FollowingViewModel: ObservableObject {
     }
     
     @MainActor
-    func requestFollowings(user: GithubUser, perPage: Int, page: Int) async -> Result<Void, GitHubAPIError> {
+    func requestFollowings(user: String, perPage: Int, page: Int) async -> Result<Void, GitHubAPIError> {
         
         let followingsResult = await service.requestUserFollowingList(userName: user, perPage: perPage, page: page)
         

--- a/GitSpace/Sources/Views/Chat/MainChat/ChatUserRecommendationSection.swift
+++ b/GitSpace/Sources/Views/Chat/MainChat/ChatUserRecommendationSection.swift
@@ -130,14 +130,14 @@ struct ChatUserRecommendationSection: View {
                 
                 Spacer()
                 
-                ForEach(followerViewModel.responses.indices,id: \.self) { index in
-                    
-                    Circle()
-                        .fill(Color.gsGreenPrimary.opacity(currentIndex == index ? 1 : 0.3))
-                        .frame(width: 7, height: 7)
-                        .scaleEffect(currentIndex == index ? 1.4 : 1)
-                        .animation(.spring(), value: currentIndex == index)
-                }
+//                ForEach(followerViewModel.responses.indices,id: \.self) { index in
+//
+//                    Circle()
+//                        .fill(Color.gsGreenPrimary.opacity(currentIndex == index ? 1 : 0.3))
+//                        .frame(width: 7, height: 7)
+//                        .scaleEffect(currentIndex == index ? 1.4 : 1)
+//                        .animation(.spring(), value: currentIndex == index)
+//                }
                 
                 Spacer()
             }
@@ -225,8 +225,8 @@ struct Carousel<Content: View, T: Identifiable>: View {
 
 
 
-struct ChatRecommandCardSection_Previews: PreviewProvider {
-    static var previews: some View {
-        ChatUserRecommendationSection(followerViewModel: FollowerViewModel())
-    }
-}
+//struct ChatRecommandCardSection_Previews: PreviewProvider {
+//    static var previews: some View {
+//        ChatUserRecommendationSection(followerViewModel: FollowerViewModel())
+//    }
+//}

--- a/GitSpace/Sources/Views/Chat/MainChat/MainChatView.swift
+++ b/GitSpace/Sources/Views/Chat/MainChat/MainChatView.swift
@@ -12,7 +12,7 @@ struct MainChatView: View {
     let gitHubService = GitHubService()
     
     @EnvironmentObject var chatStore : ChatStore
-    @StateObject var followerViewModel = FollowerViewModel()
+    //@StateObject var followerViewModel = FollowerViewModel()
     @State private var showGuideCenter: Bool = false
 	@State public var chatID: String?
     
@@ -20,24 +20,24 @@ struct MainChatView: View {
         
         ScrollView {
             // FIXME: - 팔로워 0명일때 분기처리
-            ChatUserRecommendationSection(followerViewModel: followerViewModel)
-				.padding()
-            Divider()
+//            ChatUserRecommendationSection(followerViewModel: followerViewModel)
+//				.padding()
+//            Divider()
             ChatListSection(chatID: $chatID)
         }
-        .onAppear {
-            Task {
-                let followerResult = await gitHubService.requestAuthenticatedUserFollowers(perPage: 100, page: 1)
-                switch followerResult {
-                case .success(let followers):
-                    followerViewModel.responses.removeAll()
-                    followerViewModel.responses = Array(followers.shuffled()[0...2])
-                    await followerViewModel.requestUsers()
-                case .failure(let error):
-                    print(error)
-                }
-            }
-        }
+//        .onAppear {
+//            Task {
+//                let followerResult = await gitHubService.requestAuthenticatedUserFollowers(perPage: 100, page: 1)
+//                switch followerResult {
+//                case .success(let followers):
+//                    followerViewModel.responses.removeAll()
+//                    followerViewModel.responses = Array(followers.shuffled()[0...2])
+//                    await followerViewModel.requestUsers()
+//                case .failure(let error):
+//                    print(error)
+//                }
+//            }
+//        }
         .navigationTitle("")
 		.toolbar {
 			ToolbarItem(placement: .navigationBarLeading) {

--- a/GitSpace/Sources/Views/Profile/CurrentUserProfileView.swift
+++ b/GitSpace/Sources/Views/Profile/CurrentUserProfileView.swift
@@ -118,7 +118,7 @@ struct CurrentUserProfileView: View {
                         .foregroundColor(.gsGray2)
 
                     NavigationLink {
-                        TargetUserFollowerListView(service: gitHubService, targetUserLogin: gitHubAuthManager.authenticatedUser?.login ?? "")
+                        TargetUserFollowerListView(service: gitHubService, targetUserLogin: gitHubAuthManager.authenticatedUser?.login ?? "", followers: gitHubAuthManager.authenticatedUser?.followers ?? 0)
                     } label: {
                         HStack {
                             GSText.CustomTextView(style: .title4, string: handleCountUnit(countInfo: gitHubAuthManager.authenticatedUser?.followers ?? 0))
@@ -133,7 +133,7 @@ struct CurrentUserProfileView: View {
                         .padding(.trailing, -9)
 
                     NavigationLink {
-                        TargetUserFollowingListView(service: gitHubService, targetUserLogin: gitHubAuthManager.authenticatedUser?.login ?? "")
+                        TargetUserFollowingListView(service: gitHubService, targetUserLogin: gitHubAuthManager.authenticatedUser?.login ?? "", following: gitHubAuthManager.authenticatedUser?.following ?? 0)
                     } label: {
                         HStack {
                             GSText.CustomTextView(style: .title4, string: handleCountUnit(countInfo: gitHubAuthManager.authenticatedUser?.following ?? 0))

--- a/GitSpace/Sources/Views/Profile/CurrentUserProfileView.swift
+++ b/GitSpace/Sources/Views/Profile/CurrentUserProfileView.swift
@@ -133,7 +133,7 @@ struct CurrentUserProfileView: View {
                         .padding(.trailing, -9)
 
                     NavigationLink {
-                        TargetUserFollowingListView(service: gitHubService, targetUser: gitHubAuthManager.authenticatedUser!)
+                        TargetUserFollowingListView(service: gitHubService, targetUserLogin: gitHubAuthManager.authenticatedUser?.login ?? "")
                     } label: {
                         HStack {
                             GSText.CustomTextView(style: .title4, string: handleCountUnit(countInfo: gitHubAuthManager.authenticatedUser?.following ?? 0))

--- a/GitSpace/Sources/Views/Profile/CurrentUserProfileView.swift
+++ b/GitSpace/Sources/Views/Profile/CurrentUserProfileView.swift
@@ -133,7 +133,7 @@ struct CurrentUserProfileView: View {
                         .padding(.trailing, -9)
 
                     NavigationLink {
-                        Text("This Page Will Shows Following List.")
+                        TargetUserFollowingListView(service: gitHubService, targetUser: gitHubAuthManager.authenticatedUser!)
                     } label: {
                         HStack {
                             GSText.CustomTextView(style: .title4, string: handleCountUnit(countInfo: gitHubAuthManager.authenticatedUser?.following ?? 0))

--- a/GitSpace/Sources/Views/Profile/CurrentUserProfileView.swift
+++ b/GitSpace/Sources/Views/Profile/CurrentUserProfileView.swift
@@ -118,7 +118,7 @@ struct CurrentUserProfileView: View {
                         .foregroundColor(.gsGray2)
 
                     NavigationLink {
-                        Text("This Page Will Shows Followers List.")
+                        TargetUserFollowerListView(service: gitHubService, targetUserLogin: gitHubAuthManager.authenticatedUser?.login ?? "")
                     } label: {
                         HStack {
                             GSText.CustomTextView(style: .title4, string: handleCountUnit(countInfo: gitHubAuthManager.authenticatedUser?.followers ?? 0))

--- a/GitSpace/Sources/Views/Profile/FollowingSkeletonView.swift
+++ b/GitSpace/Sources/Views/Profile/FollowingSkeletonView.swift
@@ -1,0 +1,20 @@
+//
+//  FollowingSkeletonView.swift
+//  GitSpace
+//
+//  Created by 최한호 on 2023/03/22.
+//
+
+import SwiftUI
+
+struct FollowingSkeletonView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct FollowingSkeletonView_Previews: PreviewProvider {
+    static var previews: some View {
+        FollowingSkeletonView()
+    }
+}

--- a/GitSpace/Sources/Views/Profile/FollowingSkeletonView.swift
+++ b/GitSpace/Sources/Views/Profile/FollowingSkeletonView.swift
@@ -22,7 +22,7 @@ struct FollowingSkeletonView: View {
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .clipShape(Circle())
-                        .frame(width: 40)
+                        .frame(width: 50)
                     
                     VStack(alignment: .leading, spacing: 3) {
                         /* 유저네임 */

--- a/GitSpace/Sources/Views/Profile/FollowingSkeletonView.swift
+++ b/GitSpace/Sources/Views/Profile/FollowingSkeletonView.swift
@@ -13,7 +13,7 @@ struct FollowingSkeletonView: View {
     
     var body: some View {
         VStack {
-            ForEach(0..<11) { _ in
+            ForEach(0..<10) { _ in
                 
                 HStack(spacing: 20) {
                     

--- a/GitSpace/Sources/Views/Profile/FollowingSkeletonView.swift
+++ b/GitSpace/Sources/Views/Profile/FollowingSkeletonView.swift
@@ -8,8 +8,50 @@
 import SwiftUI
 
 struct FollowingSkeletonView: View {
+    
+    @State var opacity: CGFloat = 0.4
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack {
+            ForEach(0..<11) { _ in
+                
+                HStack(spacing: 20) {
+                    
+                    /* 유저 프로필 이미지 */
+                    Image("ProfilePlaceholder")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .clipShape(Circle())
+                        .frame(width: 40)
+                    
+                    VStack(alignment: .leading, spacing: 3) {
+                        /* 유저네임 */
+                        GSText.CustomTextView(
+                            style: .caption1,
+                            string: "User Name Skeleton")
+                        .modifier(BlinkingSkeletonModifier(opacity: opacity, shouldShow: true))
+                        
+                        /* 유저ID */
+                        GSText.CustomTextView(
+                            style: .caption1,
+                            string: "User    Login")
+                        .modifier(BlinkingSkeletonModifier(opacity: opacity, shouldShow: true))
+                    } // VStack
+                    .multilineTextAlignment(.leading)
+                    
+                    Spacer()
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 10)
+                
+                Divider()
+            } // ForEach
+        } // VStack
+        .task {
+            withAnimation(.linear(duration: 1.0).repeatForever(autoreverses: true)){
+                self.opacity = opacity == 0.4 ? 0.8 : 0.4
+            }
+        }
     }
 }
 

--- a/GitSpace/Sources/Views/Profile/TargetUserFollowingListView.swift
+++ b/GitSpace/Sources/Views/Profile/TargetUserFollowingListView.swift
@@ -21,69 +21,93 @@ struct TargetUserFollowerListView: View {
     }
     
     @State var isLoading: Bool = true
+    @State var perPage: Int = 20
+    @State var currentPage: Int = 1
     
     var body: some View {
         ScrollView {
-            if !isLoading {
-                VStack {
-                    ForEach(followerViewModel.followers) { user in
-                        
-                        NavigationLink(destination: TargetUserProfileView(user: user)) {
-                            HStack(spacing: 20) {
-                                GithubProfileImage(urlStr: user.avatar_url, size: 50)
-                                
-                                VStack(alignment: .leading, spacing: 3) {
-                                    /* 유저네임 */
-                                    GSText.CustomTextView(
-                                        style: .title3,
-                                        string: user.name ?? user.login)
-                                    
-                                    /* 유저ID */
-                                    GSText.CustomTextView(
-                                        style: .caption1,
-                                        string: user.login)
-                                    
-                                    /* 유저 Bio */
-                                    if user.bio != nil {
-                                        Text("\(user.bio!)")
-                                            .font(.system(size: 12))
-                                            .foregroundColor(.primary)
-                                    }
-                                } // VStack
-                                .multilineTextAlignment(.leading)
-                                
-                                Spacer()
-                            } // HStack
-                        }
-                        .padding(.horizontal, 20)
-                        .padding(.vertical, 10)
-                        
-                        Divider()
-                    }
-                } // VStack
-            } else {
+            
+            if isLoading && currentPage == 1 {
                 FollowingSkeletonView()
-            }
-        }
+            } else {
+                VStack {
+                    ForEach(Array(zip(followerViewModel.followers.indices, followerViewModel.followers)), id: \.0) { index, user in
+                        
+                        LazyVStack {
+                            NavigationLink(destination: TargetUserProfileView(user: user)) {
+                                HStack(spacing: 20) {
+                                    
+                                    VStack {
+                                        GithubProfileImage(urlStr: user.avatar_url, size: 50)
+                                        Spacer()
+                                    } // VStack
+                                    
+                                    VStack(alignment: .leading, spacing: 3) {
+                                        /* 유저네임 */
+                                        GSText.CustomTextView(
+                                            style: .title3,
+                                            string: user.name ?? user.login)
+                                        
+                                        /* 유저ID */
+                                        GSText.CustomTextView(
+                                            style: .caption1,
+                                            string: user.login)
+                                        
+                                        /* 유저 Bio */
+                                        if user.bio != nil {
+                                            Text("\(user.bio!)")
+                                                .font(.system(size: 12))
+                                                .foregroundColor(.primary)
+                                        }
+                                    } // VStack
+                                    .multilineTextAlignment(.leading)
+                                    
+                                    Spacer()
+                                } // HStack
+                            } // NavigationLink
+                            .padding(.horizontal, 20)
+                            .padding(.vertical, 10)
+                            .onAppear {
+                                // Paging Logic
+                                if index % 20 == 15 {
+                                    currentPage += 1
+                                    requestTargetUserFollowerList()
+                                }
+                            } // onAppear
+                            
+                            Divider()
+                        } // LazyVStack
+                    } // ForEach
+                    
+                    if isLoading && currentPage > 1 {
+                        ProgressView()
+                    }
+                    
+                } // VStack
+            } // if-else
+        } // ScrollView
         .navigationBarTitle("\(followers) followers", displayMode: .inline)
         .task {
             requestTargetUserFollowerList()
         }
         .refreshable {
+            // 값 초기화
+            followerViewModel.followers.removeAll()
+            followerViewModel.temporaryFollowers.removeAll()
+            currentPage = 1
+            
             requestTargetUserFollowerList()
         }
     } // body
     
     private func requestTargetUserFollowerList() -> Void {
-        followerViewModel.followers.removeAll()
-        followerViewModel.temporaryFollowers.removeAll()
         
         withAnimation(.easeInOut) {
             isLoading = true
         }
         
         Task {
-            let followerListResult = await followerViewModel.requestFollowers(user: targetUserLogin, perPage: 100, page: 1)
+            let followerListResult = await followerViewModel.requestFollowers(user: targetUserLogin, perPage: perPage, page: currentPage)
             
             switch followerListResult {
             case .success():
@@ -112,69 +136,92 @@ struct TargetUserFollowingListView: View {
     }
     
     @State var isLoading: Bool = true
+    @State var perPage: Int = 20
+    @State var currentPage: Int = 1
     
     var body: some View {
         ScrollView {
-            if !isLoading {
-                VStack {
-                    ForEach(followingViewModel.followings) { user in
-                        
-                        NavigationLink(destination: TargetUserProfileView(user: user)) {
-                            HStack(spacing: 20) {
-                                GithubProfileImage(urlStr: user.avatar_url, size: 50)
-                                
-                                VStack(alignment: .leading, spacing: 3) {
-                                    /* 유저네임 */
-                                    GSText.CustomTextView(
-                                        style: .title3,
-                                        string: user.name ?? user.login)
-                                    
-                                    /* 유저ID */
-                                    GSText.CustomTextView(
-                                        style: .caption1,
-                                        string: user.login)
-                                    
-                                    /* 유저 Bio */
-                                    if user.bio != nil {
-                                        Text("\(user.bio!)")
-                                            .font(.system(size: 12))
-                                            .foregroundColor(.primary)
-                                    }
-                                } // VStack
-                                .multilineTextAlignment(.leading)
-                                
-                                Spacer()
-                            } // HStack
-                        }
-                        .padding(.horizontal, 20)
-                        .padding(.vertical, 10)
-                        
-                        Divider()
-                    }
-                } // VStack
-            } else {
+            if isLoading && currentPage == 1 {
                 FollowingSkeletonView()
-            }
-        }
+            } else {
+                VStack {
+                    ForEach(Array(zip(followingViewModel.followings.indices, followingViewModel.followings)), id: \.0) { index, user in
+                        
+                        LazyVStack {
+                            NavigationLink(destination: TargetUserProfileView(user: user)) {
+                                HStack(spacing: 20) {
+                                    
+                                    VStack {
+                                        GithubProfileImage(urlStr: user.avatar_url, size: 50)
+                                        Spacer()
+                                    } // VStack
+                                    
+                                    VStack(alignment: .leading, spacing: 3) {
+                                        /* 유저네임 */
+                                        GSText.CustomTextView(
+                                            style: .title3,
+                                            string: user.name ?? user.login)
+                                        
+                                        /* 유저ID */
+                                        GSText.CustomTextView(
+                                            style: .caption1,
+                                            string: user.login)
+                                        
+                                        /* 유저 Bio */
+                                        if user.bio != nil {
+                                            Text("\(user.bio!)")
+                                                .font(.system(size: 12))
+                                                .foregroundColor(.primary)
+                                        }
+                                    } // VStack
+                                    .multilineTextAlignment(.leading)
+                                    
+                                    Spacer()
+                                } // HStack
+                            } // NavigationLink
+                            .padding(.horizontal, 20)
+                            .padding(.vertical, 10)
+                            .onAppear {
+                                // Paging Logic
+                                if index % 20 == 15 {
+                                    currentPage += 1
+                                    requestTargetUserFollowingList()
+                                }
+                            } // onAppear
+                            
+                            Divider()
+                        } // LazyVStack
+                    } // ForEach
+                    
+                    if isLoading && currentPage > 1 {
+                        ProgressView()
+                    }
+                    
+                } // VStack
+            } // if-else
+        } // ScrollView
         .navigationBarTitle("\(following) following", displayMode: .inline)
         .task {
             requestTargetUserFollowingList()
         }
         .refreshable {
+            // 값 초기화
+            followingViewModel.followings.removeAll()
+            followingViewModel.temporaryFollowings.removeAll()
+            currentPage = 1
+            
             requestTargetUserFollowingList()
         }
     } // body
     
     private func requestTargetUserFollowingList() -> Void {
-        followingViewModel.followings.removeAll()
-        followingViewModel.temporaryFollowings.removeAll()
         
         withAnimation(.easeInOut) {
             isLoading = true
         }
         
         Task {
-            let followingListResult = await followingViewModel.requestFollowings(user: targetUserLogin, perPage: 100, page: 1)
+            let followingListResult = await followingViewModel.requestFollowings(user: targetUserLogin, perPage: perPage, page: currentPage)
             
             switch followingListResult {
             case .success():

--- a/GitSpace/Sources/Views/Profile/TargetUserFollowingListView.swift
+++ b/GitSpace/Sources/Views/Profile/TargetUserFollowingListView.swift
@@ -40,8 +40,15 @@ struct TargetUserFollowerListView: View {
                                     
                                     /* 유저ID */
                                     GSText.CustomTextView(
-                                        style: .sectionTitle,
+                                        style: .caption1,
                                         string: user.login)
+                                    
+                                    /* 유저 Bio */
+                                    if user.bio != nil {
+                                        Text("\(user.bio!)")
+                                            .font(.system(size: 12))
+                                            .foregroundColor(.primary)
+                                    }
                                 } // VStack
                                 .multilineTextAlignment(.leading)
                                 
@@ -124,8 +131,15 @@ struct TargetUserFollowingListView: View {
                                     
                                     /* 유저ID */
                                     GSText.CustomTextView(
-                                        style: .sectionTitle,
+                                        style: .caption1,
                                         string: user.login)
+                                    
+                                    /* 유저 Bio */
+                                    if user.bio != nil {
+                                        Text("\(user.bio!)")
+                                            .font(.system(size: 12))
+                                            .foregroundColor(.primary)
+                                    }
                                 } // VStack
                                 .multilineTextAlignment(.leading)
                                 

--- a/GitSpace/Sources/Views/Profile/TargetUserFollowingListView.swift
+++ b/GitSpace/Sources/Views/Profile/TargetUserFollowingListView.swift
@@ -1,0 +1,54 @@
+//
+//  TargetUserFollowingListView.swift
+//  GitSpace
+//
+//  Created by 최한호 on 2023/03/20.
+//
+
+import SwiftUI
+
+struct TargetUserFollowingListView: View {
+    
+    @StateObject var followingViewModel = FollowingViewModel(service: GitHubService())
+    
+    let gitHubService: GitHubService
+    let targetUser: GithubUser
+    
+    init(service: GitHubService, targetUser: GithubUser) {
+        self.gitHubService = service
+        self.targetUser = targetUser
+    }
+    
+    var body: some View {
+        ScrollView() {
+            VStack {
+                ForEach(followingViewModel.followings) { user in
+                    
+                    NavigationLink(destination: TargetUserProfileView(user: user)) {
+                        GithubProfileImage(urlStr: user.avatar_url, size: 40)
+                    }
+                }
+            }
+        }
+        .navigationBarTitle("Following", displayMode: .inline)
+        .task {
+            followingViewModel.followings.removeAll()
+            followingViewModel.temporaryFollowings.removeAll()
+            
+            let followingListResult = await followingViewModel.requestFollowings(user: targetUser, perPage: 30, page: 1)
+            
+            switch followingListResult {
+            case .success():
+                followingViewModel.followings = followingViewModel.temporaryFollowings
+            case .failure(let error):
+                print(error)
+            }
+        }
+    }
+}
+
+struct TargetUserFollowingListView_Previews: PreviewProvider {
+    static var previews: some View {
+        TargetUserFollowingListView(service: GitHubService(), targetUser: GithubUser(id: 123, login: "alexandrethsilva", name: "Alexandre Theodoro da Silva helaksdkfjslekfkfkfkllllllllkkkk", email: "asdf@mnawe.com", avatar_url: "asdf", bio: "asdf", company: "asdf", location: "asdf", blog: "asdf", public_repos: 123, followers: 123, following: 123))
+    }
+}

--- a/GitSpace/Sources/Views/Profile/TargetUserFollowingListView.swift
+++ b/GitSpace/Sources/Views/Profile/TargetUserFollowingListView.swift
@@ -12,45 +12,53 @@ struct TargetUserFollowerListView: View {
     @StateObject var followerViewModel = FollowerViewModel(service: GitHubService())
     let gitHubService: GitHubService
     let targetUserLogin: String
+    let followers: Int
     
-    init(service: GitHubService, targetUserLogin: String) {
+    init(service: GitHubService, targetUserLogin: String, followers: Int) {
         self.gitHubService = service
         self.targetUserLogin = targetUserLogin
+        self.followers = followers
     }
+    
+    @State var isLoading: Bool = true
     
     var body: some View {
         ScrollView {
-            VStack {
-                ForEach(followerViewModel.followers) { user in
-                    
-                    NavigationLink(destination: TargetUserProfileView(user: user)) {
-                        HStack(spacing: 20) {
-                            GithubProfileImage(urlStr: user.avatar_url, size: 50)
-                            
-                            VStack(alignment: .leading, spacing: 3) {
-                                /* 유저네임 */
-                                GSText.CustomTextView(
-                                    style: .title3,
-                                    string: user.name ?? user.login)
+            if !isLoading {
+                VStack {
+                    ForEach(followerViewModel.followers) { user in
+                        
+                        NavigationLink(destination: TargetUserProfileView(user: user)) {
+                            HStack(spacing: 20) {
+                                GithubProfileImage(urlStr: user.avatar_url, size: 50)
                                 
-                                /* 유저ID */
-                                GSText.CustomTextView(
-                                    style: .sectionTitle,
-                                    string: user.login)
-                            } // VStack
-                            .multilineTextAlignment(.leading)
-                            
-                            Spacer()
-                        } // HStack
+                                VStack(alignment: .leading, spacing: 3) {
+                                    /* 유저네임 */
+                                    GSText.CustomTextView(
+                                        style: .title3,
+                                        string: user.name ?? user.login)
+                                    
+                                    /* 유저ID */
+                                    GSText.CustomTextView(
+                                        style: .sectionTitle,
+                                        string: user.login)
+                                } // VStack
+                                .multilineTextAlignment(.leading)
+                                
+                                Spacer()
+                            } // HStack
+                        }
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 10)
+                        
+                        Divider()
                     }
-                    .padding(.horizontal, 20)
-                    .padding(.vertical, 10)
-                    
-                    Divider()
-                }
-            } // VStack
+                } // VStack
+            } else {
+                FollowingSkeletonView()
+            }
         }
-        .navigationBarTitle(targetUserLogin, displayMode: .inline)
+        .navigationBarTitle("\(followers) followers", displayMode: .inline)
         .task {
             requestTargetUserFollowerList()
         }
@@ -63,12 +71,19 @@ struct TargetUserFollowerListView: View {
         followerViewModel.followers.removeAll()
         followerViewModel.temporaryFollowers.removeAll()
         
+        withAnimation(.easeInOut) {
+            isLoading = true
+        }
+        
         Task {
             let followerListResult = await followerViewModel.requestFollowers(user: targetUserLogin, perPage: 100, page: 1)
             
             switch followerListResult {
             case .success():
                 followerViewModel.followers = followerViewModel.temporaryFollowers
+                withAnimation(.easeInOut) {
+                    isLoading = false
+                }
             case .failure(let error):
                 print(error)
             }
@@ -81,45 +96,53 @@ struct TargetUserFollowingListView: View {
     @StateObject var followingViewModel = FollowingViewModel(service: GitHubService())
     let gitHubService: GitHubService
     let targetUserLogin: String
+    let following: Int
     
-    init(service: GitHubService, targetUserLogin: String) {
+    init(service: GitHubService, targetUserLogin: String, following: Int) {
         self.gitHubService = service
         self.targetUserLogin = targetUserLogin
+        self.following = following
     }
+    
+    @State var isLoading: Bool = true
     
     var body: some View {
         ScrollView {
-            VStack {
-                ForEach(followingViewModel.followings) { user in
-                    
-                    NavigationLink(destination: TargetUserProfileView(user: user)) {
-                        HStack(spacing: 20) {
-                            GithubProfileImage(urlStr: user.avatar_url, size: 50)
-                            
-                            VStack(alignment: .leading, spacing: 3) {
-                                /* 유저네임 */
-                                GSText.CustomTextView(
-                                    style: .title3,
-                                    string: user.name ?? user.login)
+            if !isLoading {
+                VStack {
+                    ForEach(followingViewModel.followings) { user in
+                        
+                        NavigationLink(destination: TargetUserProfileView(user: user)) {
+                            HStack(spacing: 20) {
+                                GithubProfileImage(urlStr: user.avatar_url, size: 50)
                                 
-                                /* 유저ID */
-                                GSText.CustomTextView(
-                                    style: .sectionTitle,
-                                    string: user.login)
-                            } // VStack
-                            .multilineTextAlignment(.leading)
-                            
-                            Spacer()
-                        } // HStack
+                                VStack(alignment: .leading, spacing: 3) {
+                                    /* 유저네임 */
+                                    GSText.CustomTextView(
+                                        style: .title3,
+                                        string: user.name ?? user.login)
+                                    
+                                    /* 유저ID */
+                                    GSText.CustomTextView(
+                                        style: .sectionTitle,
+                                        string: user.login)
+                                } // VStack
+                                .multilineTextAlignment(.leading)
+                                
+                                Spacer()
+                            } // HStack
+                        }
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 10)
+                        
+                        Divider()
                     }
-                    .padding(.horizontal, 20)
-                    .padding(.vertical, 10)
-                    
-                    Divider()
-                }
-            } // VStack
+                } // VStack
+            } else {
+                FollowingSkeletonView()
+            }
         }
-        .navigationBarTitle(targetUserLogin, displayMode: .inline)
+        .navigationBarTitle("\(following) following", displayMode: .inline)
         .task {
             requestTargetUserFollowingList()
         }
@@ -132,12 +155,19 @@ struct TargetUserFollowingListView: View {
         followingViewModel.followings.removeAll()
         followingViewModel.temporaryFollowings.removeAll()
         
+        withAnimation(.easeInOut) {
+            isLoading = true
+        }
+        
         Task {
             let followingListResult = await followingViewModel.requestFollowings(user: targetUserLogin, perPage: 100, page: 1)
             
             switch followingListResult {
             case .success():
                 followingViewModel.followings = followingViewModel.temporaryFollowings
+                withAnimation(.easeInOut) {
+                    isLoading = false
+                }
             case .failure(let error):
                 print(error)
             }
@@ -147,6 +177,6 @@ struct TargetUserFollowingListView: View {
 
 struct TargetUserFollowingListView_Previews: PreviewProvider {
     static var previews: some View {
-        TargetUserFollowingListView(service: GitHubService(), targetUserLogin: "guguhanogu")
+        TargetUserFollowingListView(service: GitHubService(), targetUserLogin: "guguhanogu", following: 123)
     }
 }

--- a/GitSpace/Sources/Views/Profile/TargetUserFollowingListView.swift
+++ b/GitSpace/Sources/Views/Profile/TargetUserFollowingListView.swift
@@ -7,35 +7,133 @@
 
 import SwiftUI
 
-struct TargetUserFollowingListView: View {
+struct TargetUserFollowerListView: View {
     
-    @StateObject var followingViewModel = FollowingViewModel(service: GitHubService())
-    
+    @StateObject var followerViewModel = FollowerViewModel(service: GitHubService())
     let gitHubService: GitHubService
-    let targetUser: GithubUser
+    let targetUserLogin: String
     
-    init(service: GitHubService, targetUser: GithubUser) {
+    init(service: GitHubService, targetUserLogin: String) {
         self.gitHubService = service
-        self.targetUser = targetUser
+        self.targetUserLogin = targetUserLogin
     }
     
     var body: some View {
-        ScrollView() {
+        ScrollView {
+            VStack {
+                ForEach(followerViewModel.followers) { user in
+                    
+                    NavigationLink(destination: TargetUserProfileView(user: user)) {
+                        HStack(spacing: 20) {
+                            GithubProfileImage(urlStr: user.avatar_url, size: 50)
+                            
+                            VStack(alignment: .leading, spacing: 3) {
+                                /* 유저네임 */
+                                GSText.CustomTextView(
+                                    style: .title3,
+                                    string: user.name ?? user.login)
+                                
+                                /* 유저ID */
+                                GSText.CustomTextView(
+                                    style: .sectionTitle,
+                                    string: user.login)
+                            } // VStack
+                            .multilineTextAlignment(.leading)
+                            
+                            Spacer()
+                        } // HStack
+                    }
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 10)
+                    
+                    Divider()
+                }
+            } // VStack
+        }
+        .navigationBarTitle(targetUserLogin, displayMode: .inline)
+        .task {
+            requestTargetUserFollowerList()
+        }
+        .refreshable {
+            requestTargetUserFollowerList()
+        }
+    } // body
+    
+    private func requestTargetUserFollowerList() -> Void {
+        followerViewModel.followers.removeAll()
+        followerViewModel.temporaryFollowers.removeAll()
+        
+        Task {
+            let followerListResult = await followerViewModel.requestFollowers(user: targetUserLogin, perPage: 100, page: 1)
+            
+            switch followerListResult {
+            case .success():
+                followerViewModel.followers = followerViewModel.temporaryFollowers
+            case .failure(let error):
+                print(error)
+            }
+        }
+    }
+}
+
+struct TargetUserFollowingListView: View {
+    
+    @StateObject var followingViewModel = FollowingViewModel(service: GitHubService())
+    let gitHubService: GitHubService
+    let targetUserLogin: String
+    
+    init(service: GitHubService, targetUserLogin: String) {
+        self.gitHubService = service
+        self.targetUserLogin = targetUserLogin
+    }
+    
+    var body: some View {
+        ScrollView {
             VStack {
                 ForEach(followingViewModel.followings) { user in
                     
                     NavigationLink(destination: TargetUserProfileView(user: user)) {
-                        GithubProfileImage(urlStr: user.avatar_url, size: 40)
+                        HStack(spacing: 20) {
+                            GithubProfileImage(urlStr: user.avatar_url, size: 50)
+                            
+                            VStack(alignment: .leading, spacing: 3) {
+                                /* 유저네임 */
+                                GSText.CustomTextView(
+                                    style: .title3,
+                                    string: user.name ?? user.login)
+                                
+                                /* 유저ID */
+                                GSText.CustomTextView(
+                                    style: .sectionTitle,
+                                    string: user.login)
+                            } // VStack
+                            .multilineTextAlignment(.leading)
+                            
+                            Spacer()
+                        } // HStack
                     }
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 10)
+                    
+                    Divider()
                 }
-            }
+            } // VStack
         }
-        .navigationBarTitle("Following", displayMode: .inline)
+        .navigationBarTitle(targetUserLogin, displayMode: .inline)
         .task {
-            followingViewModel.followings.removeAll()
-            followingViewModel.temporaryFollowings.removeAll()
-            
-            let followingListResult = await followingViewModel.requestFollowings(user: targetUser, perPage: 30, page: 1)
+            requestTargetUserFollowingList()
+        }
+        .refreshable {
+            requestTargetUserFollowingList()
+        }
+    } // body
+    
+    private func requestTargetUserFollowingList() -> Void {
+        followingViewModel.followings.removeAll()
+        followingViewModel.temporaryFollowings.removeAll()
+        
+        Task {
+            let followingListResult = await followingViewModel.requestFollowings(user: targetUserLogin, perPage: 100, page: 1)
             
             switch followingListResult {
             case .success():
@@ -49,6 +147,6 @@ struct TargetUserFollowingListView: View {
 
 struct TargetUserFollowingListView_Previews: PreviewProvider {
     static var previews: some View {
-        TargetUserFollowingListView(service: GitHubService(), targetUser: GithubUser(id: 123, login: "alexandrethsilva", name: "Alexandre Theodoro da Silva helaksdkfjslekfkfkfkllllllllkkkk", email: "asdf@mnawe.com", avatar_url: "asdf", bio: "asdf", company: "asdf", location: "asdf", blog: "asdf", public_repos: 123, followers: 123, following: 123))
+        TargetUserFollowingListView(service: GitHubService(), targetUserLogin: "guguhanogu")
     }
 }

--- a/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
+++ b/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
@@ -23,6 +23,7 @@ struct TargetUserProfileView: View {
     @State private var isFailedToLoadReadme = false
 
     let user: GithubUser
+    let gitHubService = GitHubService()
 
     init(user: GithubUser) {
         self.user = user
@@ -56,10 +57,12 @@ struct TargetUserProfileView: View {
 
                     if let bio = user.bio {
                         // MARK: - bio
-                        VStack(alignment: .leading) {
+                        HStack() {
                             GSText.CustomTextView(style: .body1, string: bio)
+                            Spacer()
                         }
                             .padding(15)
+                            .font(.callout)
                             .frame(maxWidth: .infinity)
                             .multilineTextAlignment(.leading)
                             .background(Color.gsGray3)
@@ -120,26 +123,31 @@ struct TargetUserProfileView: View {
                             .frame(width: 15, height: 15)
                             .foregroundColor(.gsGray2)
 
-                        // TODO: - NavigationLink: 팔로워 리스트
-                        HStack {
-                            GSText.CustomTextView(style: .title4, string: handleCountUnit(countInfo: user.followers))
-                            GSText.CustomTextView(style: .description, string: "followers")
-                                .padding(.leading, -2)
-                        }
-
+                        NavigationLink {
+                            TargetUserFollowerListView(service: gitHubService, targetUserLogin: user.login, followers: user.followers)
+                        } label: {
+                            HStack {
+                                GSText.CustomTextView(style: .title4, string: handleCountUnit(countInfo: user.followers))
+                                GSText.CustomTextView(style: .sectionTitle, string: "followers")
+                                    .padding(.leading, -2)
+                            }
+                        } // NavigationLink
+                        
                         Text("･")
                             .foregroundColor(.gsGray2)
                             .padding(.leading, -3)
                             .padding(.trailing, -9)
-
-                        // TODO: - NavigationLink: 팔로잉 리스트
-                        HStack {
-                            GSText.CustomTextView(style: .title4, string: handleCountUnit(countInfo: user.following))
-                            GSText.CustomTextView(style: .description, string: "following")
-                                .padding(.leading, -2)
-                        }
+                        
+                        NavigationLink {
+                            TargetUserFollowingListView(service: gitHubService, targetUserLogin: user.login, following: user.following)
+                        } label: {
+                            HStack {
+                                GSText.CustomTextView(style: .title4, string: handleCountUnit(countInfo: user.following))
+                                GSText.CustomTextView(style: .sectionTitle, string: "following")
+                                    .padding(.leading, -2)
+                            }
+                        } // NavigationLink
                     }
-
                 }
 
                 // 내 프로필인지 아닌지에 따라 분기처리


### PR DESCRIPTION
## 개요 및 관련 이슈
- TargetUser의 Following과 Followers List를 호출하는 함수를 구현하고 적용합니다.

## 작업 사항
- GitHubAPIEndpoint에 case를 추가하였습니다.
    - `case userFollowingList(userName: String, perPage: Int, page: Int)`
    - `case userFollowerList(userName: String, perPage: Int, page: Int)`
- GitHubServiceProtocol에 함수를 추가하였습니다.
```swift
/// 특정 유저의 Following List를 요청하는 함수
func requestUserFollowingList(userName: String, perPage: Int, page: Int) async -> Result<[FollowingResponse], GitHubAPIError>
    
/// 특정 유저의 Follower List를 요청하는 함수
func requestUserFollowerList(userName: String, perPage: Int, page: Int) async -> Result<[FollowingResponse], GitHubAPIError>
```
- GitHubService에 함수를 구현하였습니다.
```swift
func requestUserFollowingList(userName: String, perPage: Int, page: Int) async -> Result<[FollowingResponse], GitHubAPIError> {
        return await sendRequest(endpoint: GitHubAPIEndpoint.userFollowingList(userName: userName, perPage: perPage, page: page), responseModel: [FollowingResponse].self)
    }

func requestUserFollowerList(userName: String, perPage: Int, page: Int) async -> Result<[FollowingResponse], GitHubAPIError> {
        return await sendRequest(endpoint: GitHubAPIEndpoint.userFollowerList(userName: userName, perPage: perPage, page: page), responseModel: [FollowingResponse].self)
    }
```
- ` FollowingViewModel `을 구현하였습니다.
- ` FollowerViewModel `을 구현하였습니다.
- Following 목록을 보여줄 뷰(` TargetUserFollowingListView `)를 구현하였습니다.
- Follower 목록을 보여줄 뷰(` TargetUserFollowerListView `)를 구현하였습니다.
- TargetUser의 프로필과 연결하였습니다.
- 무한 스크롤을 구현하였습니다.