### PR TITLE
[HotFix] 신규 유저정보 등록 시 deviceToken 필드가 정상적으로 반영되지 않는 문제를 해결했습니다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ iOSInjectionProject/
 # HIDE SECRETS
 */*.xcconfig
 *.xcconfig
+
+# PList
+*.plist

--- a/.gitignore
+++ b/.gitignore
@@ -97,4 +97,4 @@ iOSInjectionProject/
 *.xcconfig
 
 # PList
-*.plist
+**/*.plist

--- a/GitSpace/Resources/App/plist/GoogleService-Info.plist
+++ b/GitSpace/Resources/App/plist/GoogleService-Info.plist
@@ -3,21 +3,21 @@
 <plist version="1.0">
 <dict>
 	<key>CLIENT_ID</key>
-	<string>144879966378-k2trt85438fm0qghi5a3uchbc27qsvcg.apps.googleusercontent.com</string>
+	<string>856592841917-a0uqb29mstng5oeqtj9cjkrhmdt95j5b.apps.googleusercontent.com</string>
 	<key>REVERSED_CLIENT_ID</key>
-	<string>com.googleusercontent.apps.144879966378-k2trt85438fm0qghi5a3uchbc27qsvcg</string>
+	<string>com.googleusercontent.apps.856592841917-a0uqb29mstng5oeqtj9cjkrhmdt95j5b</string>
 	<key>API_KEY</key>
-	<string>AIzaSyBXApCb_OjBVq99Ssb5n_RbWJRhl8D5PHs</string>
+	<string>AIzaSyCh4YcHMxZiHaiGwSJsbrzfi1KRRzYGAiA</string>
 	<key>GCM_SENDER_ID</key>
-	<string>144879966378</string>
+	<string>856592841917</string>
 	<key>PLIST_VERSION</key>
 	<string>1</string>
 	<key>BUNDLE_ID</key>
 	<string>com.GitSpace.RBG</string>
 	<key>PROJECT_ID</key>
-	<string>gitspace-b2d4f</string>
+	<string>gitspace-release</string>
 	<key>STORAGE_BUCKET</key>
-	<string>gitspace-b2d4f.appspot.com</string>
+	<string>gitspace-release.appspot.com</string>
 	<key>IS_ADS_ENABLED</key>
 	<false></false>
 	<key>IS_ANALYTICS_ENABLED</key>
@@ -29,6 +29,6 @@
 	<key>IS_SIGNIN_ENABLED</key>
 	<true></true>
 	<key>GOOGLE_APP_ID</key>
-	<string>1:144879966378:ios:5bd0f07094b11f399518d3</string>
+	<string>1:856592841917:ios:85dd2f0b111addbd0ecbd4</string>
 </dict>
 </plist>

--- a/GitSpace/Resources/App/plist/Info.plist
+++ b/GitSpace/Resources/App/plist/Info.plist
@@ -17,7 +17,7 @@
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>com.googleusercontent.apps.144879966378-kjvh4sdkd2okm0gfggvs7bjg9ums6tfk</string>
+				<string>com.googleusercontent.apps.856592841917-a0uqb29mstng5oeqtj9cjkrhmdt95j5b</string>
 			</array>
 		</dict>
 		<dict>
@@ -25,7 +25,7 @@
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>com.googleusercontent.apps.144879966378-k2trt85438fm0qghi5a3uchbc27qsvcg</string>
+				<string>com.googleusercontent.apps.856592841917-a0uqb29mstng5oeqtj9cjkrhmdt95j5b</string>
 			</array>
 		</dict>
 	</array>

--- a/GitSpace/Sources/ViewModels/GitHubAuthManager.swift
+++ b/GitSpace/Sources/ViewModels/GitHubAuthManager.swift
@@ -92,25 +92,27 @@ final class GitHubAuthManager: ObservableObject {
                     githubRequest.addValue("Bearer \(at)", forHTTPHeaderField: "Authorization")
                     
                     let task = session.dataTask(with: githubRequest) { data, response, error in
-                        guard error == nil else {
-                            print("SignIn Task Error: ", error?.localizedDescription as Any)
-                            return
-                        }
-                        guard let userData = data else {
-                            print("SignIn Decoded Error: ", error?.localizedDescription as Any)
-                            return
-                        }
-                        
-                        self.authenticatedUser = DecodingManager.decodeData(userData, GithubUser.self)
-                        
-                        guard self.authenticatedUser != nil else {
-                            return
-                        }
-                        
-                        self.registerNewUser(self.authenticatedUser!)
-                        
-                        DispatchQueue.main.async {
-                            self.state = .signedIn
+                        Task {
+                            guard error == nil else {
+                                print("SignIn Task Error: ", error?.localizedDescription as Any)
+                                return
+                            }
+                            guard let userData = data else {
+                                print("SignIn Decoded Error: ", error?.localizedDescription as Any)
+                                return
+                            }
+                            
+                            self.authenticatedUser = DecodingManager.decodeData(userData, GithubUser.self)
+                            
+                            guard self.authenticatedUser != nil else {
+                                return
+                            }
+                            
+                            await self.registerNewUser(self.authenticatedUser!)
+                            
+                            DispatchQueue.main.async {
+                                self.state = .signedIn
+                            }
                         }
                     }
                     task.resume()

--- a/GitSpace/Sources/ViewModels/GitHubAuthManager.swift
+++ b/GitSpace/Sources/ViewModels/GitHubAuthManager.swift
@@ -121,6 +121,16 @@ final class GitHubAuthManager: ObservableObject {
         }
     }
     
+    private func requestUserDocument(userID: String) async -> DocumentSnapshot? {
+        do {
+            let snapshot = try await database.collection(const.COLLECTION_USER_INFO).document(userID).getDocument()
+            return snapshot
+        } catch {
+            print("Error-\(#file)-\(#function) : \(error.localizedDescription)")
+            return nil
+        }
+    }
+    
     // existUser에서 가입일시를 받아서 새 user 만들기 + Github API 닉네임과 UserInfo 닉네임이 일치하지 않으면 업데이트
     // MARK: Method - Auth의 currentUser를 통해 UserInfo에 이미 존재하는 유저인지 여부를 반환하는 메서드
     // Github Auth 로그인 수행 -> User DB에서 이미 존재하는지 체크 -> 가입날짜 유지 및 나머지 정보 최신으로 갱신

--- a/GitSpace/Sources/ViewModels/GitHubAuthManager.swift
+++ b/GitSpace/Sources/ViewModels/GitHubAuthManager.swift
@@ -136,7 +136,7 @@ final class GitHubAuthManager: ObservableObject {
     // Github Auth 로그인 수행 -> User DB에서 이미 존재하는지 체크 -> 가입날짜 유지 및 나머지 정보 최신으로 갱신
     // MARK: - Register New User at Firestore
     /// Firestore에 새로운 회원을 등록합니다.
-    private func registerNewUser(_ githubUser: GithubUser) {
+    private func registerNewUser(_ githubUser: GithubUser) async {
         
         if let firebaseAuthUID = authentification.currentUser?.uid {
             // 현재 Auth 로그인 uid로 UserInfo에 접근

--- a/GitSpace/Sources/ViewModels/GitHubAuthManager.swift
+++ b/GitSpace/Sources/ViewModels/GitHubAuthManager.swift
@@ -208,6 +208,25 @@ final class GitHubAuthManager: ObservableObject {
                      following: FBUser.following)
     }
     
+    private func getFirestoreUser(uid: String, githubUser: GithubUser) -> UserInfo {
+        return .init(id: uid,
+                     createdDate: .now,
+                     deviceToken: "",
+                     blockedUserIDs: [],
+                     githubID: githubUser.id,
+                     githubLogin: githubUser.login,
+                     githubName: githubUser.name,
+                     githubEmail: githubUser.email,
+                     avatar_url: githubUser.avatar_url,
+                     bio: githubUser.bio,
+                     company: githubUser.company,
+                     location: githubUser.location,
+                     blog: githubUser.blog,
+                     public_repos: githubUser.public_repos,
+                     followers: githubUser.followers,
+                     following: githubUser.following)
+    }
+    
     /**
      기존 Firestore UserInfo와 업데이트된 GithubUser를 통해서 업데이트된 Firestore UserInfo를 생성하는 메서드
      

--- a/GitSpace/Sources/ViewModels/GitHubAuthManager.swift
+++ b/GitSpace/Sources/ViewModels/GitHubAuthManager.swift
@@ -77,10 +77,6 @@ final class GitHubAuthManager: ObservableObject {
                     guard let oauthCredential = authResult?.credential as? OAuthCredential else {
                         return
                     }
-                    // 아래 guard문을 삭제하지 않으면 로그인 시 무한 로딩에 걸림.
-//                    guard KeyChainManager.create(authCredential: credential) == true else { return }
-//                    print(KeyChainManager.read())
-                    
                     // Github 사용자 데이터(name, email)을 가져오기 위해서 GitHub REST API request가 필요하다.
                     guard let githubAuthenticatedUserURL = URL(string: "https://api.github.com/user") else {
                         return

--- a/GitSpace/Sources/ViewModels/UserViewModel.swift
+++ b/GitSpace/Sources/ViewModels/UserViewModel.swift
@@ -242,17 +242,17 @@ final class UserStore: ObservableObject {
             for eachType in updateType {
                 switch eachType {
                 case let .deviceToken(token):
-                    try await document.setData([
+                    try await document.updateData([
                         const.FIELD_DEVICE_TOKEN: token
-                    ], merge: true)
+                    ])
                 case let .knockPushNotificationAceeptance(isKnockPushAvailable):
-                    try await document.setData([
+                    try await document.updateData([
                         const.FIELD_IS_KNOCK_PUSH_AVAILABLE: isKnockPushAvailable
-                    ], merge: true)
+                    ])
                 case let .chatPushNotificationAceeptance(isChatPushAvailable):
-                    try await document.setData([
+                    try await document.updateData([
                         const.FIELD_IS_CHAT_PUSH_AVAILABLE: isChatPushAvailable
-                    ], merge: true)
+                    ])
                 }
             }
         } catch {


### PR DESCRIPTION
## 개요 및 관련 이슈
- #357 

## 작업 사항
- GithubAuthManager의 signIn 메서드 로직을 비동기로 전환
- registerNewUser에 await 키워드를 추가하여, UserInfo가 DB에 정상적으로 추가된 후 ContentView로 전환되도록 수정
