### PR TITLE
[Feat] #367 차단/신고 뷰를 구현했습니다.

### DIFF
--- a/GitSpace/Sources/Models/Report.swift
+++ b/GitSpace/Sources/Models/Report.swift
@@ -31,4 +31,12 @@ struct Report: Codable {
         case cheating = "Cheating"
         case bullying = "Cyberbullying or Harassment"
     }
+    
+    enum ReportReasonDescription: String, CaseIterable {
+        case spamming = "Spamming Description"
+        case offensive = "Verbal Abuse, Offensive Language Description"
+        case sexual = "Sexual Description(Activity) Description"
+        case cheating = "Cheating Description"
+        case bullying = "Cyberbullying or Harassment Description"
+    }
 }

--- a/GitSpace/Sources/Models/Report.swift
+++ b/GitSpace/Sources/Models/Report.swift
@@ -24,7 +24,7 @@ struct Report: Codable {
         case knock = "Knock"
     }
     
-    enum ReportReason: String, Codable {
+    enum ReportReason: String, Codable, CaseIterable {
         case spamming = "Spamming"
         case offensive = "Verbal Abuse, Offensive Language"
         case sexual = "Sexual Description(Activity)"

--- a/GitSpace/Sources/Models/Report.swift
+++ b/GitSpace/Sources/Models/Report.swift
@@ -33,10 +33,10 @@ struct Report: Codable {
     }
     
     enum ReportReasonDescription: String, CaseIterable {
-        case spamming = "Spamming Description"
-        case offensive = "Verbal Abuse, Offensive Language Description"
-        case sexual = "Sexual Description(Activity) Description"
-        case cheating = "Cheating Description"
-        case bullying = "Cyberbullying or Harassment Description"
+        case spammingDescription = "Spamming Description"
+        case offensiveDescription = "Verbal Abuse, Offensive Language Description"
+        case sexualDescription = "Sexual Description(Activity) Description"
+        case cheatingDescription = "Cheating Description"
+        case bullyingDescription = "Cyberbullying or Harassment Description"
     }
 }

--- a/GitSpace/Sources/Views/Common/BlockView.swift
+++ b/GitSpace/Sources/Views/Common/BlockView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct BlockView: View {
-    @Environment(\.dismiss) private var dismiss
+    @Binding var isBlockViewShowing: Bool
     
     var body: some View {
         VStack {
@@ -39,8 +39,7 @@ struct BlockView: View {
                 
                 HStack {
                     GSButton.CustomButtonView(style: .plainText(isDestructive: false)) {
-                        print("no")
-                        dismiss()
+                        isBlockViewShowing.toggle()
                     } label: {
                         Text("No")
                     }
@@ -48,8 +47,7 @@ struct BlockView: View {
                     
                     GSButton.CustomButtonView(style: .secondary(isDisabled: false)) {
                         /* Block Method Call */
-                        print("yes")
-                        dismiss()
+                        isBlockViewShowing.toggle()
                     } label: {
                         Text("Yes")
                     }
@@ -61,6 +59,6 @@ struct BlockView: View {
 
 struct BlockView_Previews: PreviewProvider {
     static var previews: some View {
-        BlockView()
+        BlockView(isBlockViewShowing: .constant(true))
     }
 }

--- a/GitSpace/Sources/Views/Common/BlockView.swift
+++ b/GitSpace/Sources/Views/Common/BlockView.swift
@@ -1,0 +1,66 @@
+//
+//  BlockView.swift
+//  GitSpace
+//
+//  Created by Da Hae Lee on 2023/04/19.
+//
+
+import SwiftUI
+
+struct BlockView: View {
+    @Environment(\.dismiss) private var dismiss
+    
+    var body: some View {
+        VStack {
+            GSText.CustomTextView(style: .title2, string: "Block")
+            
+            VStack(alignment: .leading) {
+                GSText.CustomTextView(
+                    style: .body1,
+                    string: "When you block this user, the following things happen.")
+                .padding(.bottom, 1)
+                GSText.CustomTextView(
+                    style: .description,
+                    string:
+"""
+• You cannot knock/chat with this user.
+• This user is classified as a blocked user at repository contributors.
+"""
+                )
+            }
+            .padding(.top, 10)
+            .padding(.bottom, 30)
+            
+            VStack {
+                GSText.CustomTextView(
+                    style: .title3, string: "If you want to block this user?"
+                )
+                .padding(10)
+                
+                HStack {
+                    GSButton.CustomButtonView(style: .plainText(isDestructive: false)) {
+                        print("no")
+                        dismiss()
+                    } label: {
+                        Text("No")
+                    }
+                    .padding([.leading, .trailing], 20)
+                    
+                    GSButton.CustomButtonView(style: .secondary(isDisabled: false)) {
+                        /* Block Method Call */
+                        print("yes")
+                        dismiss()
+                    } label: {
+                        Text("Yes")
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct BlockView_Previews: PreviewProvider {
+    static var previews: some View {
+        BlockView()
+    }
+}

--- a/GitSpace/Sources/Views/Common/ReportView.swift
+++ b/GitSpace/Sources/Views/Common/ReportView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct ReportView: View {
     @Environment(\.dismiss) private var dismiss
-    
+    @Binding var isReportViewShowing: Bool
     @Binding var isSuggestBlockViewShowing: Bool
     
     @State private var reportReason: String?
@@ -119,10 +119,11 @@ Gitspace operation team will check and help you.
                 style: .secondary(isDisabled: isReportReasonSelected)
             ) {
                 /* report method call */
-                print("Submit Report")
+                
                 /* report view dismiss -> suggest block view appear*/
                 dismiss()
-                isSuggestBlockViewShowing = true
+                isReportViewShowing.toggle()
+                isSuggestBlockViewShowing.toggle()
             } label: {
                 Text("Submit Report")
             }
@@ -134,6 +135,6 @@ Gitspace operation team will check and help you.
 
 struct ReportView_Previews: PreviewProvider {
     static var previews: some View {
-        ReportView(isSuggestBlockViewShowing: .constant(false))
+        ReportView(isReportViewShowing: .constant(true), isSuggestBlockViewShowing: .constant(false))
     }
 }

--- a/GitSpace/Sources/Views/Common/ReportView.swift
+++ b/GitSpace/Sources/Views/Common/ReportView.swift
@@ -1,0 +1,139 @@
+//
+//  ReportView.swift
+//  GitSpace
+//
+//  Created by Da Hae Lee on 2023/04/19.
+//
+
+import SwiftUI
+
+struct ReportView: View {
+    @Environment(\.dismiss) private var dismiss
+    
+    @Binding var isSuggestBlockViewShowing: Bool
+    
+    @State private var reportReason: String?
+    @State private var reportReasonNumber: Int?
+    
+    var isReportReasonSelected: Bool {
+        guard reportReasonNumber != nil else {
+            return false
+        }
+        return true
+    }
+        
+    var body: some View {
+        VStack {
+            /* Report Title */
+            GSText.CustomTextView(style: .title2, string: "Report")
+                .padding()
+            
+            /* Report Description */
+            VStack(alignment: .leading) {
+                GSText.CustomTextView(
+                    style: .body1,
+                    string: "When you Report this user, the following things happen.")
+                .padding(.bottom, 1)
+
+                GSText.CustomTextView(
+                    style: .caption1,
+                    string:
+"""
+• The selected content is sent to Gitspace for review.
+• The report is not delivered to the other user.
+""")
+
+            }
+                        
+            /* Select Report Reason Description */
+            VStack(alignment: .leading) {
+                GSText.CustomTextView(
+                    style: .body1,
+                    string:
+"""
+Please Tell me what happened with this user. Select one of the reporting categories below.
+Gitspace operation team will check and help you.
+""")
+                .padding(10)
+            }
+            
+            /* Select Report Reason */
+            ForEach(
+                Array(zip(Report.ReportReason.allCases, (0...Report.ReportReason.allCases.count-1))),
+                id:\.0
+            ) { (reason, index) in
+                Divider()
+                VStack(alignment: .leading) {
+                    HStack {
+                        GSText.CustomTextView(
+                            style: .title3,
+                            string: "\(reason.rawValue)"
+                        )
+                        Spacer()
+                        Image(systemName: (isReportReasonSelected && reportReasonNumber == index)
+                              ? "checkmark.circle.fill"
+                              : "circle"
+                        )
+                    }
+                    .padding([.leading,.trailing])
+                    .padding([.top, .bottom], 5)
+                    .contentShape(Rectangle())  /// HStack을 전부 탭 영역으로 잡기 위해 추가함.
+                    .onTapGesture {
+                        /**
+                         차단 이유를 선택합니다.
+                         단, 이미 선택한 이유를 다시 재선택하면 deselection 됩니다.
+                         */
+                        if isReportReasonSelected && reportReasonNumber == index {
+                            withAnimation {
+                                reportReasonNumber = nil
+                                reportReason = nil
+                            }
+                        } else {
+                            withAnimation {
+                                reportReasonNumber = index
+                                reportReason = reason.rawValue
+                            }
+                        }
+                    }
+                    
+                    if (isReportReasonSelected && reportReasonNumber == index) {
+                        GSText.CustomTextView(
+                            style: .caption1,
+                            string:
+                                "\(Report.ReportReasonDescription.allCases[index].rawValue)"
+                        )
+                        .padding(EdgeInsets(top: 0, leading: 18, bottom: 10, trailing: 50))
+                        .transition(
+                            .asymmetric(
+                                insertion: .opacity,
+                                removal: .opacity)
+                            .animation(.easeInOut(duration: 0.3))
+                        )
+                    }
+                }
+            }
+            Divider()
+            
+            /* Submit Report */
+            GSButton.CustomButtonView(
+                style: .secondary(isDisabled: isReportReasonSelected)
+            ) {
+                /* report method call */
+                print("Submit Report")
+                /* report view dismiss -> suggest block view appear*/
+                dismiss()
+                isSuggestBlockViewShowing = true
+            } label: {
+                Text("Submit Report")
+            }
+            .padding()
+            .disabled(!isReportReasonSelected) /// GSButton의 isDisabled이 작동하지 않아서 따로 수정자 붙임.
+        }
+    }
+}
+
+struct ReportView_Previews: PreviewProvider {
+    static var previews: some View {
+        ReportView(isSuggestBlockViewShowing: .constant(false))
+    }
+}

--- a/GitSpace/Sources/Views/Common/SuggestBlockView.swift
+++ b/GitSpace/Sources/Views/Common/SuggestBlockView.swift
@@ -9,12 +9,13 @@ import SwiftUI
 
 struct SuggestBlockView: View {
     @Environment(\.dismiss) private var dismiss
-    
     @Binding var isBlockViewShowing: Bool
+    @Binding var isSuggestBlockViewShowing: Bool
     
     var body: some View {
         VStack {
             VStack {
+//                let _ = print("!!\(isSuggestBlockViewShowing) \(isBlockViewShowing)")
                 GSText.CustomTextView(style: .title1, string: "Report Submitted")
                 GSText.CustomTextView(style: .description, string: "Your report is submitted. ")
             }
@@ -27,17 +28,15 @@ struct SuggestBlockView: View {
             
             HStack {
                 GSButton.CustomButtonView(style: .plainText(isDestructive: false)) {
-                    print("no")
-                    dismiss()
+                    isSuggestBlockViewShowing.toggle()
                 } label: {
                     Text("No")
                 }
                 .padding([.leading, .trailing], 20)
                 
                 GSButton.CustomButtonView(style: .secondary(isDisabled: false)) {
-                    print("yes")
                     dismiss()
-                    isBlockViewShowing = true
+                    isBlockViewShowing.toggle()
                 } label: {
                     Text("Yes")
                 }
@@ -49,6 +48,6 @@ struct SuggestBlockView: View {
 
 struct SuggestBlockView_Previews: PreviewProvider {
     static var previews: some View {
-        SuggestBlockView(isBlockViewShowing: .constant(false))
+        SuggestBlockView(isBlockViewShowing: .constant(false), isSuggestBlockViewShowing: .constant(true))
     }
 }

--- a/GitSpace/Sources/Views/Common/SuggestBlockView.swift
+++ b/GitSpace/Sources/Views/Common/SuggestBlockView.swift
@@ -1,0 +1,54 @@
+//
+//  SuggestBlockView.swift
+//  GitSpace
+//
+//  Created by Da Hae Lee on 2023/04/19.
+//
+
+import SwiftUI
+
+struct SuggestBlockView: View {
+    @Environment(\.dismiss) private var dismiss
+    
+    @Binding var isBlockViewShowing: Bool
+    
+    var body: some View {
+        VStack {
+            VStack {
+                GSText.CustomTextView(style: .title1, string: "Report Submitted")
+                GSText.CustomTextView(style: .description, string: "Your report is submitted. ")
+            }
+            .padding()
+            
+            VStack(alignment: .leading) {
+                GSText.CustomTextView(style: .title3, string: "Well... Do you want to Block this user?")
+            }
+            .padding()
+            
+            HStack {
+                GSButton.CustomButtonView(style: .plainText(isDestructive: false)) {
+                    print("no")
+                    dismiss()
+                } label: {
+                    Text("No")
+                }
+                .padding([.leading, .trailing], 20)
+                
+                GSButton.CustomButtonView(style: .secondary(isDisabled: false)) {
+                    print("yes")
+                    dismiss()
+                    isBlockViewShowing = true
+                } label: {
+                    Text("Yes")
+                }
+            }
+
+        }
+    }
+}
+
+struct SuggestBlockView_Previews: PreviewProvider {
+    static var previews: some View {
+        SuggestBlockView(isBlockViewShowing: .constant(false))
+    }
+}

--- a/GitSpace/Sources/Views/Common/SuggestBlockView.swift
+++ b/GitSpace/Sources/Views/Common/SuggestBlockView.swift
@@ -15,7 +15,6 @@ struct SuggestBlockView: View {
     var body: some View {
         VStack {
             VStack {
-//                let _ = print("!!\(isSuggestBlockViewShowing) \(isBlockViewShowing)")
                 GSText.CustomTextView(style: .title1, string: "Report Submitted")
                 GSText.CustomTextView(style: .description, string: "Your report is submitted. ")
             }

--- a/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
+++ b/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
@@ -317,15 +317,20 @@ struct TargetUserProfileView: View {
                         .frame(width: 40, height: 40)
                 }
             }
-
-            .sheet(isPresented: $isBlockViewShowing) {
-                BlockView()
+            .halfSheet(showSheet: $isBlockViewShowing) {
+                BlockView(isBlockViewShowing: $isBlockViewShowing)
+            } onEnd: {
+                /* 모달 닫히고 난 뒤 필요한 로직 호출 */
             }
-            .sheet(isPresented: $isReportViewShowing) {
-                ReportView(isSuggestBlockViewShowing: $isSuggestBlockViewShowing)
+            .halfSheet(showSheet: $isReportViewShowing) {
+                ReportView(isReportViewShowing: $isReportViewShowing, isSuggestBlockViewShowing: $isSuggestBlockViewShowing)
+            } onEnd: {
+                /* 모달 닫히고 난 뒤 필요한 로직 호출 */
             }
-            .sheet(isPresented: $isSuggestBlockViewShowing) {
-                SuggestBlockView(isBlockViewShowing: $isBlockViewShowing)
+            .halfSheet(showSheet: $isSuggestBlockViewShowing) {
+                SuggestBlockView(isBlockViewShowing: $isBlockViewShowing, isSuggestBlockViewShowing: $isSuggestBlockViewShowing)
+            } onEnd: {
+                /* 모달 닫히고 난 뒤 필요한 로직 호출 */
             }
     } //  body
 }

--- a/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
+++ b/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
@@ -292,6 +292,28 @@ struct TargetUserProfileView: View {
                 }
             }
         }
+            .toolbar {
+                Menu {
+                    Section {
+                        Button(role: .destructive, action: {
+                            /* Block 모달 뷰 appear */
+                            isBlockViewShowing.toggle()
+                        }) {
+                            Label("Block", systemImage: "nosign")
+                        }
+                        
+                        Button(role: .destructive, action: {
+                            /* Report 모달 뷰 appear */
+                            isReportViewShowing.toggle()
+                        }) {
+                            Label("Report", systemImage: "exclamationmark.bubble")
+                        }
+                    }
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .frame(width: 40, height: 40)
+                }
+            }
 
     } //  body
 }

--- a/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
+++ b/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
@@ -317,20 +317,14 @@ struct TargetUserProfileView: View {
                         .frame(width: 40, height: 40)
                 }
             }
-            .halfSheet(showSheet: $isBlockViewShowing) {
+            .halfSheet(isPresented: $isBlockViewShowing) {
                 BlockView(isBlockViewShowing: $isBlockViewShowing)
-            } onEnd: {
-                /* 모달 닫히고 난 뒤 필요한 로직 호출 */
             }
-            .halfSheet(showSheet: $isReportViewShowing) {
+            .halfSheet(isPresented: $isReportViewShowing) {
                 ReportView(isReportViewShowing: $isReportViewShowing, isSuggestBlockViewShowing: $isSuggestBlockViewShowing)
-            } onEnd: {
-                /* 모달 닫히고 난 뒤 필요한 로직 호출 */
             }
-            .halfSheet(showSheet: $isSuggestBlockViewShowing) {
+            .halfSheet(isPresented: $isSuggestBlockViewShowing) {
                 SuggestBlockView(isBlockViewShowing: $isBlockViewShowing, isSuggestBlockViewShowing: $isSuggestBlockViewShowing)
-            } onEnd: {
-                /* 모달 닫히고 난 뒤 필요한 로직 호출 */
             }
     } //  body
 }

--- a/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
+++ b/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
@@ -22,6 +22,9 @@ struct TargetUserProfileView: View {
     @State private var isGitSpaceUser = false
     @State private var isFailedToLoadReadme = false
     @State private var isEmptyReadme = false
+    @State private var isBlockViewShowing = false
+    @State private var isReportViewShowing = false
+    @State private var isSuggestBlockViewShowing = false
 
     let user: GithubUser
     let gitHubService = GitHubService()
@@ -315,5 +318,14 @@ struct TargetUserProfileView: View {
                 }
             }
 
+            .sheet(isPresented: $isBlockViewShowing) {
+                BlockView()
+            }
+            .sheet(isPresented: $isReportViewShowing) {
+                ReportView(isSuggestBlockViewShowing: $isSuggestBlockViewShowing)
+            }
+            .sheet(isPresented: $isSuggestBlockViewShowing) {
+                SuggestBlockView(isBlockViewShowing: $isBlockViewShowing)
+            }
     } //  body
 }

--- a/GitSpace/Utilities/CustomHostingController.swift
+++ b/GitSpace/Utilities/CustomHostingController.swift
@@ -1,0 +1,33 @@
+//
+//  CustomHostingController.swift
+//  GitSpace
+//
+//  Created by Da Hae Lee on 2023/04/20.
+//
+
+import SwiftUI
+
+class CustomHostingController<Content: View>: UIHostingController<Content> {
+
+    override func viewDidLoad() {
+        view.backgroundColor = .systemBackground
+        print(rootView)
+        // setting presentation controller properties
+        if let presentationController = presentationController as? UISheetPresentationController {
+            
+            switch rootView {
+            case is ReportView:
+                presentationController.detents = [
+                    .large()
+                ]
+            default:
+                presentationController.detents = [
+                    .medium(),
+                    .large()
+                ]
+            }
+            // to show grab protion
+            presentationController.prefersGrabberVisible = true
+        }
+    }
+}

--- a/GitSpace/Utilities/Extensions/View+.swift
+++ b/GitSpace/Utilities/Extensions/View+.swift
@@ -53,17 +53,17 @@ extension View {
     /// Half Sheet를 사용할 수 있는 View의 Extension이다.
     /// iOS 15의 SwiftUI에서는 Sheet의 크기를 조절하는 API가 없다.
     /// 그러므로 HalfSheetManager를 background에 사용하여 half modal을 구현한다.
-    func halfSheet<SheetView: View>(
-        showSheet: Binding<Bool>,
-        @ViewBuilder sheetView: @escaping ()->SheetView,
-        onEnd: @escaping ()->()
+    func halfSheet<Content: View>(
+        isPresented: Binding<Bool>,
+        onDismiss: (() -> ())? = nil,
+        @ViewBuilder content: @escaping () -> Content
     ) -> some View {
         return self
             .background {
                  HalfSheetManager(
-                    showSheet: showSheet,
-                    sheetView: sheetView(),
-                    onEnd: onEnd
+                    isPresented: isPresented,
+                    onDismiss: onDismiss,
+                    content: content()
                  )
             }
     }

--- a/GitSpace/Utilities/Extensions/View+.swift
+++ b/GitSpace/Utilities/Extensions/View+.swift
@@ -48,4 +48,23 @@ extension View {
     func onViewDidLoad(perform action: (() -> Void)? = nil) -> some View {
         self.modifier(ViewDidLoadModifier(action: action))
     }
+    
+    // MARK: - Half Sheet을 사용하기 위한 Extension
+    /// Half Sheet를 사용할 수 있는 View의 Extension이다.
+    /// iOS 15의 SwiftUI에서는 Sheet의 크기를 조절하는 API가 없다.
+    /// 그러므로 HalfSheetManager를 background에 사용하여 half modal을 구현한다.
+    func halfSheet<SheetView: View>(
+        showSheet: Binding<Bool>,
+        @ViewBuilder sheetView: @escaping ()->SheetView,
+        onEnd: @escaping ()->()
+    ) -> some View {
+        return self
+            .background {
+                 HalfSheetManager(
+                    showSheet: showSheet,
+                    sheetView: sheetView(),
+                    onEnd: onEnd
+                 )
+            }
+    }
 }

--- a/GitSpace/Utilities/Extensions/View+.swift
+++ b/GitSpace/Utilities/Extensions/View+.swift
@@ -41,7 +41,7 @@ extension View {
         return handledCount
     }
     
-    // MARK: SwiftUI에서 ViewDidLoad를 구현하기 위한 Extension
+    // MARK: - SwiftUI에서 ViewDidLoad를 구현하기 위한 Extension
     /// 뷰가 메모리에 로드될 경우 수행되게 하는 ViewDidLoad 함수.
     /// UIKit에는 viewDidLoad 함수가 있지만 SwiftUI에는 존재하지 않는다.
     /// 그러므로 onAppear을 사용하여 직접 viewDidLoad를 수정자로 구현한다.

--- a/GitSpace/Utilities/HalfSheetManager.swift
+++ b/GitSpace/Utilities/HalfSheetManager.swift
@@ -1,0 +1,50 @@
+//
+//  HalfSheetManager.swift
+//  GitSpace
+//
+//  Created by Da Hae Lee on 2023/04/20.
+//
+
+import SwiftUI
+import UIKit
+
+struct HalfSheetManager<SheetView: View>: UIViewControllerRepresentable {
+    @Binding var showSheet: Bool
+    var sheetView: SheetView
+    var onEnd: () -> ()
+    let controller = UIViewController()
+
+    func makeCoordinator() -> Coordinator {
+        return Coordinator(parent: self)
+    }
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        controller.view.backgroundColor = .clear
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+        if showSheet {
+            let sheetController = CustomHostingController(rootView: sheetView)
+            sheetController.presentationController?.delegate = context.coordinator
+            uiViewController.present(sheetController, animated: true)
+        } else {
+            // choosing view when showsheet toggled againg
+            uiViewController.dismiss(animated: true)
+        }
+    }
+    
+    // On dismiss
+    class Coordinator: NSObject, UISheetPresentationControllerDelegate {
+        var parent: HalfSheetManager
+
+        init(parent: HalfSheetManager) {
+            self.parent = parent
+        }
+
+        func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+            parent.showSheet = false
+            parent.onEnd()
+        }
+    }
+}

--- a/GitSpace/Utilities/HalfSheetManager.swift
+++ b/GitSpace/Utilities/HalfSheetManager.swift
@@ -8,10 +8,10 @@
 import SwiftUI
 import UIKit
 
-struct HalfSheetManager<SheetView: View>: UIViewControllerRepresentable {
-    @Binding var showSheet: Bool
-    var sheetView: SheetView
-    var onEnd: () -> ()
+struct HalfSheetManager<Content: View>: UIViewControllerRepresentable {
+    @Binding var isPresented: Bool
+    var onDismiss: (() -> ())?
+    var content: Content
     let controller = UIViewController()
 
     func makeCoordinator() -> Coordinator {
@@ -24,8 +24,8 @@ struct HalfSheetManager<SheetView: View>: UIViewControllerRepresentable {
     }
 
     func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
-        if showSheet {
-            let sheetController = CustomHostingController(rootView: sheetView)
+        if isPresented {
+            let sheetController = CustomHostingController(rootView: content)
             sheetController.presentationController?.delegate = context.coordinator
             uiViewController.present(sheetController, animated: true)
         } else {
@@ -43,8 +43,10 @@ struct HalfSheetManager<SheetView: View>: UIViewControllerRepresentable {
         }
 
         func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
-            parent.showSheet = false
-            parent.onEnd()
+            parent.isPresented = false
+            if parent.onDismiss != nil {
+                parent.onDismiss!()
+            }
         }
     }
 }


### PR DESCRIPTION
## 개요 및 관련 이슈
- 차단/신고 프로세스가 수행되는 뷰를 구현했습니다.
- #367 

## 작업 사항
- 차단/신고 프로세스를 수행할 수 있는 뷰 정리(이슈에 작성 완료)

#### View
- `BlockView`
- `ReportView`
- `SuggestBlockView`: 신고 후 차단할 지 물어보는 뷰

#### Enum
- `Report.ReportReasonDescription` 생성
    - ReportView에서 신고를 설명하기 위해 Enum을 새롭게 추가하였다.
    - Report와 연관을 짓고, 휴먼 에러를 줄이기 위해 Enum을 선택하였다.
- `Report.ReportReason`에 `CaseIterable` 프로토콜 추가
    - Enum이 가진 모든 값의 컬렉션을 제공할 수 있도록 하는 프로토콜이다.
<!--
    - ReportView에서 반복문으로 Report Reason과 그의 Description을 보여줘야 했다. 그러나 Enum의 값을 컬렉션으로 가져올 수 없다. 이를 위해 CaseIterable을 채택다. 결과적으로 Enum의 모든 값에 접근할 수 있었고, 반복문으로 각각의 Reason의 rawValue를 텍스트로 출력할 수 있었다.
-->

#### Half Sheet
> iOS 15에는 Sheet의 크기를 설정할 수 없어서 Custom으로 구현하였다.
- `halfSheet`: halfSheet를 사용할 때 View의 수정자로 작성하면 된다.
    - View Extension에 구현되어 있다. 
    - TargetUserProfileView에서 사용 중이다.
- `HalfSheetManager`: 
- `CustomHostingController`: HostingController에서 UISheetPresentationController 사용

## 주요 로직(Optional)
#### 차단/신고 뷰 사용하기
> 차단/신고 뷰를 사용하려면 .halfSheet를 사용하면 된다. 사용법은 .sheet와 같다.

1. 차단/신고 모달이 나타나길 원하는 뷰에 `.halfSheet { .. }` 를 추가한다.
2. `.halfSheet`의 매개변수 `isPresented`, `content`를 채워준다.
    * 해당 뷰에 모달의 Appear을 조절할 바인딩 프로퍼티를 만들어 `isPresented`에 할당한다.
    * 모달로 띄우길 원하는 뷰를 `content`에 작성한다. 
    * **단, ReportView는 SuggestReportView도 같이 sheet로 만들어줘야 한다.**
3. 만약 dismiss 후 필요한 수행해야 하는 로직이 있다면 onDismiss에 값을 넣어주면 된다.

- 예시
```diff
struct TargetUserProfileView: View {
    // ...
    @State private var isBlockViewShowing = false
    @State private var isReportViewShowing = false
    @State private var isSuggestBlockViewShowing = false

    var body: some View {
        ScrollView(showsIndicators: false) { ... }
            .toolbar { ... }
           // BlockView
+          .halfSheet(isPresented: $isBlockViewShowing) {
+              BlockView(isBlockViewShowing: $isBlockViewShowing)
+          }
          // ReportView (위의 2개를 모두 해줘야 한다)
+          .halfSheet(isPresented: $isReportViewShowing) {
+              ReportView(isReportViewShowing: $isReportViewShowing, isSuggestBlockViewShowing: $isSuggestBlockViewShowing)
+         }
+          .halfSheet(isPresented: $isSuggestBlockViewShowing) {
+              SuggestBlockView(isBlockViewShowing: $isBlockViewShowing, isSuggestBlockViewShowing: $isSuggestBlockViewShowing)
+          }
    } //  body
}
```

#### BlockView
```swift
struct BlockView: View {
    @Binding var isBlockViewShowing: Bool
    var body: some View {
        VStack {
            // ...
            VStack {
                // ...
                HStack {
                    // Block 'No' Button
                    GSButton.CustomButtonView(style: .plainText(isDestructive: false)) {
                        isBlockViewShowing.toggle()
                    } label: {
                        Text("No")
                    }
                    // Block 'Yes' Button
                    GSButton.CustomButtonView(style: .secondary(isDisabled: false)) {
                        /* Block Method Call */
                        isBlockViewShowing.toggle()
                    } label: {
                        Text("Yes")
                    }
                }
            }
        }
    }
}
```

#### ReportView
```swift
struct ReportView: View {
    @Environment(\.dismiss) private var dismiss
    @Binding var isReportViewShowing: Bool
    @Binding var isSuggestBlockViewShowing: Bool
    // ...

    var body: some View {
        VStack {
            /* Report Title */
            /* Report Description */  
            /* Select Report Reason Description */
            /* Select Report Reason */
            ForEach(
                Array(zip(Report.ReportReason.allCases, (0...Report.ReportReason.allCases.count-1))),
                id:\.0
            ) { (reason, index) in
                Divider()
                VStack(alignment: .leading) { ... }
                    .contentShape(Rectangle())  /// HStack을 전부 탭 영역으로 잡기 위해 추가함.
                    .onTapGesture { ... }
                     /* Report Reason Description */
                    if (isReportReasonSelected && reportReasonNumber == index) { ... }
                }
            }
            Divider()
            
            /* Submit Report */
            GSButton.CustomButtonView(
                style: .secondary(isDisabled: isReportReasonSelected)
            ) {
                /* report method call */
                dismiss()
                isReportViewShowing.toggle()
                isSuggestBlockViewShowing.toggle()
            } label: {
                Text("Submit Report")
            }
            .padding()
            .disabled(!isReportReasonSelected) /// GSButton의 isDisabled이 작동하지 않아서 따로 수정자 붙임.
        }
    }
}

```

#### SuggestBlockView
특별한 부분이 없으므로 코드는 생략합니다.

#### View Extension: halfSheet
```swift
// MARK: - Half Sheet을 사용하기 위한 Extension
/// Half Sheet를 사용할 수 있는 View의 Extension이다.
/// iOS 15의 SwiftUI에서는 Sheet의 크기를 조절하는 API가 없다.
/// 그러므로 HalfSheetManager를 background에 사용하여 half modal을 구현한다.
func halfSheet<Content: View>(
  isPresented: Binding<Bool>,
  onDismiss: (() -> ())? = nil,
  @ViewBuilder content: @escaping () -> Content
) -> some View {
  return self
      .background {
           HalfSheetManager(
              isPresented: isPresented,
              onDismiss: onDismiss,
              content: content()
           )
      }
}
```

#### HalfSheetManager
```swift
struct HalfSheetManager<Content: View>: UIViewControllerRepresentable {
    @Binding var isPresented: Bool
    var onDismiss: (() -> ())?
    var content: Content
    let controller = UIViewController()

    func makeCoordinator() -> Coordinator {
        return Coordinator(parent: self)
    }

    func makeUIViewController(context: Context) -> UIViewController {
        controller.view.backgroundColor = .clear
        return controller
    }

    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
        if isPresented {
            let sheetController = CustomHostingController(rootView: content)
            sheetController.presentationController?.delegate = context.coordinator
            uiViewController.present(sheetController, animated: true)
        } else {
            // choosing view when showsheet toggled againg
            uiViewController.dismiss(animated: true)
        }
    }
    
    // On dismiss
    class Coordinator: NSObject, UISheetPresentationControllerDelegate {
        var parent: HalfSheetManager

        init(parent: HalfSheetManager) {
            self.parent = parent
        }

        func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
            parent.isPresented = false
            if parent.onDismiss != nil {
                parent.onDismiss!()
            }
        }
    }
}
```

#### CustomHostingController
ReportView는 내용이 많아서 medium일 경우 텍스트가 쪼그라드는 현상이 있다. 
그래서 rootView를 분기처리하여 ReportView일 때만 large만 가지도록 하였다.
_(iOS 15의 UISheetPresentationController에는 medium, large만 제공된다)_
```swift
class CustomHostingController<Content: View>: UIHostingController<Content> {

    override func viewDidLoad() {
        view.backgroundColor = .systemBackground
        print(rootView)
        // setting presentation controller properties
        if let presentationController = presentationController as? UISheetPresentationController {
            
            switch rootView {
            case is ReportView:
                presentationController.detents = [
                    .large()
                ]
            default:
                presentationController.detents = [
                    .medium(),
                    .large()
                ]
            }
            // to show grab protion
            presentationController.prefersGrabberVisible = true
        }
    }
}
```