### PR TITLE
[Feat] 주체 사용자(subjectUser)가 객체 사용자(objectUser)를 차단했는지 검증하는 메서드를 구현했습니다.

### DIFF
--- a/GitSpace/Sources/Network/Interface/Blockable.swift
+++ b/GitSpace/Sources/Network/Interface/Blockable.swift
@@ -42,6 +42,21 @@ protocol Blockable {
         in currentUser: UserInfo,
         with targetUser: UserInfo
     ) async throws -> Result<Void, BlockError>
+        
+    /**
+     verifyBlocked(by: , with: ) 메소드는 subjectUser가 objectUser를 차단했는지 검증하는 함수입니다.
+     subjectUser가 이미 objectUser를 차단했다면 true를 반환하고,
+     차단을 하지 않았다면 false를 반환합니다.
+     
+     - Parameters:
+        - by subjectUser: UserInfo 타입, 차단을 한 주체
+        - with objectUser: UserInfo 타입, 차단을 당한 객체
+     - Returns: - Bool
+     */
+    func verifyBlocked(
+        by subjectUser: UserInfo,
+        with objectUser: UserInfo
+    ) -> Bool
 }
 
 extension Blockable {

--- a/GitSpace/Sources/Network/Interface/Blockable.swift
+++ b/GitSpace/Sources/Network/Interface/Blockable.swift
@@ -105,7 +105,7 @@ extension Blockable {
         by subjectUser: UserInfo,
         with objectUser: UserInfo
     ) -> Bool {
-        return subjectUser.blockedUserIDs.contains(objectUser.id) ? true : false
+        return subjectUser.blockedUserIDs.contains(objectUser.id)
     }
 }
 

--- a/GitSpace/Sources/Network/Interface/Blockable.swift
+++ b/GitSpace/Sources/Network/Interface/Blockable.swift
@@ -16,9 +16,10 @@ import FirebaseFirestore
  */
 protocol Blockable {
     /**
-     blockTargetUser(with:) 메소드는 targetUser를 block하는 비동기 함수입니다.
+     blockTargetUser(in: , with: ) 메소드는 targetUser를 block하는 비동기 함수입니다.
      
      - Parameters:
+        - in currentUser: UserInfo 타입
         - with targetUser: UserInfo 타입
      - Returns: - Result<Void, BlockError>
      - throws: - BlockError enum > blockCreateFailed
@@ -29,9 +30,10 @@ protocol Blockable {
     ) async throws -> Result<Void, BlockError>
     
     /**
-     unblockTargetUser(with:) 메소드는 targetUser를 unblock 하는 비동기 함수입니다.
+     unblockTargetUser(in: , with: ) 메소드는 targetUser를 unblock 하는 비동기 함수입니다.
      
      - Parameters:
+        - in currentUser: UserInfo 타입
         - with targetUser: UserInfo 타입
      - Returns: - Result<Void, BlockError>
      - throws: - BlockError enum > unblockDeleteFailed

--- a/GitSpace/Sources/Network/Interface/Blockable.swift
+++ b/GitSpace/Sources/Network/Interface/Blockable.swift
@@ -122,6 +122,14 @@ extension Blockable {
     ) -> Bool {
         return subjectUser.blockedUserIDs.contains(objectUser.id)
     }
+    
+    func isBlockedEither(
+        by currentUser: UserInfo,
+        by targetUser: UserInfo
+    ) -> Bool {
+        return ( isBlocked(by: currentUser, with: targetUser) ||
+                 isBlocked(by: targetUser, with: currentUser) )
+    }
 }
 
 enum BlockError: Error {

--- a/GitSpace/Sources/Network/Interface/Blockable.swift
+++ b/GitSpace/Sources/Network/Interface/Blockable.swift
@@ -44,7 +44,7 @@ protocol Blockable {
     ) async throws -> Result<Void, BlockError>
         
     /**
-     verifyBlocked(by: , with: ) 메소드는 subjectUser가 objectUser를 차단했는지 검증하는 함수입니다.
+     isBlocked(by: , with: ) 메소드는 subjectUser가 objectUser를 차단했는지 검증하는 함수입니다.
      subjectUser가 이미 objectUser를 차단했다면 true를 반환하고,
      차단을 하지 않았다면 false를 반환합니다.
      
@@ -53,7 +53,7 @@ protocol Blockable {
         - with objectUser: UserInfo 타입, 차단을 당한 객체
      - Returns: - Bool
      */
-    func verifyBlocked(
+    func isBlocked(
         by subjectUser: UserInfo,
         with objectUser: UserInfo
     ) -> Bool
@@ -101,7 +101,7 @@ extension Blockable {
         }
     }
     
-    func verifyBlocked(
+    func isBlocked(
         by subjectUser: UserInfo,
         with objectUser: UserInfo
     ) -> Bool {

--- a/GitSpace/Sources/Network/Interface/Blockable.swift
+++ b/GitSpace/Sources/Network/Interface/Blockable.swift
@@ -57,6 +57,21 @@ protocol Blockable {
         by subjectUser: UserInfo,
         with objectUser: UserInfo
     ) -> Bool
+    
+    /**
+     isBlockedEither(by: , by: ) 메소드는 currentUser와 targetUser 간의 차단 상태를 확인하는 함수입니다.
+     둘 중 하나라도 차단을 했다면 true를 반환하고,
+     둘 다 차단하지 않은 상태라면 false를 반환합니다.
+     
+     - Parameters:
+        - by currentUser: UserInfo 타입
+        - by targetUser: UserInfo 타입
+     - Returns: - Bool
+     */
+    func isBlockedEither(
+        by currentUser: UserInfo,
+        by targetUser: UserInfo
+    ) -> Bool
 }
 
 extension Blockable {

--- a/GitSpace/Sources/Network/Interface/Blockable.swift
+++ b/GitSpace/Sources/Network/Interface/Blockable.swift
@@ -100,6 +100,13 @@ extension Blockable {
             return .failure(.unblockDeleteFailed)
         }
     }
+    
+    func verifyBlocked(
+        by subjectUser: UserInfo,
+        with objectUser: UserInfo
+    ) -> Bool {
+        return subjectUser.blockedUserIDs.contains(objectUser.id) ? true : false
+    }
 }
 
 enum BlockError: Error {


### PR DESCRIPTION
## 개요 및 관련 이슈
- 주체 사용자(subjectUser)가 객체 사용자(objectUser)를 차단했는지 검증하는 메서드를 구현했습니다.
- #369 

## 작업 사항
- 주체 사용자(subjectUser)가 객체 사용자(objectUser)를 차단했는지 검증하는 메서드를 구현
- 링크된 이슈에서 메서드에 대한 설명을 보실 수 있습니다.

## 주요 로직(Optional)
```swift
/**
verifyBlocked(by: , with: ) 메소드는 subjectUser가 objectUser를 차단했는지 검증하는 함수입니다.
subjectUser가 이미 objectUser를 차단했다면 true를 반환하고,
차단을 하지 않았다면 false를 반환합니다.
     
- Parameters:
    - by subjectUser: UserInfo 타입, 차단을 한 주체
    - with objectUser: UserInfo 타입, 차단을 당한 객체
- Returns: - Bool
*/
func verifyBlocked(
    by subjectUser: UserInfo,
    with objectUser: UserInfo
) -> Bool {
    return subjectUser.blockedUserIDs.contains(objectUser.id)
}
```
