### PR TITLE
[Feat] 채팅방에서 상대방 메세지를 신고할 수 있는 기능을 추가했습니다.

### DIFF
--- a/GitSpace/Sources/ViewModels/GitHubAuthManager.swift
+++ b/GitSpace/Sources/ViewModels/GitHubAuthManager.swift
@@ -178,7 +178,7 @@ final class GitHubAuthManager: ObservableObject {
      
      - Returns: FBUser의 프로퍼티를 통해 생성한 GithubUser 인스턴스
      */
-    private func getGithubUser(FBUser: UserInfo) -> GithubUser {
+    func getGithubUser(FBUser: UserInfo) -> GithubUser {
         return .init(id: FBUser.githubID,
                      login: FBUser.githubLogin,
                      name: FBUser.githubName,

--- a/GitSpace/Sources/ViewModels/MessageViewModel.swift
+++ b/GitSpace/Sources/ViewModels/MessageViewModel.swift
@@ -18,6 +18,7 @@ final class MessageStore: ObservableObject {
     @Published var messages: [Message] = []
     @Published var isMessageAdded: Bool = false
     @Published var deletedMessage: Message? // 메세지 셀 삭제 시 onChange로 반응하는 대상 메세지
+    @Published var reportedMessage: Message? // 메세지 셀 신고 시 onChange로 반응하는 대상 메세지
     @Published var isFetchMessagesDone: Bool = false
     
     var remainMessages: [Message] = []

--- a/GitSpace/Sources/ViewModels/MessageViewModel.swift
+++ b/GitSpace/Sources/ViewModels/MessageViewModel.swift
@@ -15,9 +15,8 @@ import FirebaseFirestore
 
 final class MessageStore: ObservableObject {
     
-    
-    @Published var messages: [Message]
-    @Published var isMessageAdded: Bool
+    @Published var messages: [Message] = []
+    @Published var isMessageAdded: Bool = false
     @Published var deletedMessage: Message? // 메세지 셀 삭제 시 onChange로 반응하는 대상 메세지
     @Published var isFetchMessagesDone: Bool = false
     
@@ -28,10 +27,6 @@ final class MessageStore: ObservableObject {
     private let const = Constant.FirestorePathConst.self
     var currentChat: Chat? // 채팅방 입장 시, 현재 입장한 Chat 인스턴스를 할당받음. MessageStore 내부에서 Chat DB에 접근하기 위한 변수
     
-    init() {
-        messages = []
-        isMessageAdded = false
-    }
 }
 
 // MARK: -Extension : Message CRUD 관련 함수를 모아둔 Extension

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -406,7 +406,10 @@ struct ChatRoomView: View {
             // 2
             if isNotificationReceiveEnableDict == nil {
                 // 2-1
-                let _ = UserDefaults().set([:], forKey: chatRoomNotificationKey)
+                let _ = UserDefaults().set(
+                    [:],
+                    forKey: chatRoomNotificationKey
+                )
             }
             
             if let isNotificationReceiveEnableDict {

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -147,7 +147,7 @@ struct ChatRoomView: View {
         // 상대방 MessageCell ContextMenu에서 신고 버튼을 탭하면 수행되는 로직
         .onChange(of: messageStore.reportedMessage?.id) { id in
             
-            // 다혜님이 작업한 신고 모달 프레젠트 로직 수행
+            // TODO: 다혜님의 PR에 포함된 신고 sheet present 로직 구현
             
         }
         // 유저가 앱 화면에서 벗어났을 때 수행되는 로직

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -136,7 +136,7 @@ struct ChatRoomView: View {
                 await clearUnreadMessageCount()
             }
         }
-        // MessageCell ContextMenu에서 삭제 버튼을 탭하면 수행되는 로직
+        // 내 MessageCell ContextMenu에서 삭제 버튼을 탭하면 수행되는 로직
         .onChange(of: messageStore.deletedMessage?.id) { id in
             if let id, let deletedMessage = messageStore.messages.first(where: {$0.id == id}) {
                 Task {

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -144,6 +144,12 @@ struct ChatRoomView: View {
                 }
             }
         }
+        // 상대방 MessageCell ContextMenu에서 신고 버튼을 탭하면 수행되는 로직
+        .onChange(of: messageStore.reportedMessage?.id) { id in
+            
+            // 다혜님이 작업한 신고 모달 프레젠트 로직 수행
+            
+        }
         // 유저가 앱 화면에서 벗어났을 때 수행되는 로직
         .onChange(of: scenePhase) { currentPhase in
             // FIXME: inActive 혹은 backGround에 가는 것을 채팅방을 나가는것처럼 처리해줄지, 돌아올 때 채팅방에 입장한 것처럼 처리해줄지 고려 필요. By 태영

--- a/GitSpace/Sources/Views/Chat/ChatRoom/MessageCell.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/MessageCell.swift
@@ -44,7 +44,6 @@ struct MessageCell : View {
                         }
                     }
             }
-            //.padding(.trailing, 10)
             
         case false:
             HStack {

--- a/GitSpace/Sources/Views/Chat/ChatRoom/MessageCell.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/MessageCell.swift
@@ -36,10 +36,11 @@ struct MessageCell : View {
                         MessageModifier(isMine: self.isMine)
                     )
                     .contextMenu {
-                        Button {
-                            messageStore.deletedMessage = message
+                        Button(role: .destructive) {
+                            messageStore.deletedMessage = self.message
                         } label: {
                             Text("Delete")
+                            Image(systemName: "trash")
                         }
                     }
             }

--- a/GitSpace/Sources/Views/Chat/ChatRoom/MessageCell.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/MessageCell.swift
@@ -51,7 +51,9 @@ struct MessageCell : View {
                 // Profile Image 부분
                 VStack {
                     NavigationLink {
-                        TargetUserProfileView(user: GithubUser(id: targetUserInfo.githubID, login: targetUserInfo.githubLogin, name: targetUserInfo.githubName, email: targetUserInfo.githubEmail, avatar_url: targetUserInfo.avatar_url, bio: targetUserInfo.bio, company: targetUserInfo.company, location: targetUserInfo.location, blog: targetUserInfo.blog, public_repos: targetUserInfo.public_repos, followers: targetUserInfo.followers, following: targetUserInfo.following))
+                        TargetUserProfileView (
+                            user: githubAuthManager.getGithubUser(FBUser: targetUserInfo)
+                        )
                     } label: {
                         GithubProfileImage(urlStr: targetUserInfo.avatar_url, size: 35)
                     }

--- a/GitSpace/Sources/Views/Chat/ChatRoom/MessageCell.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/MessageCell.swift
@@ -81,7 +81,7 @@ struct MessageCell : View {
                                     messageStore.reportedMessage = message
                                 } label: {
                                     Text("Report")
-                                    Image(systemName: "light.beacon.max")
+                                    Image(systemName: "exclamationmark.bubble")
                                 }
                             }
                         Text(message.sentDateAsString)

--- a/GitSpace/Sources/Views/Chat/ChatRoom/MessageCell.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/MessageCell.swift
@@ -77,6 +77,14 @@ struct MessageCell : View {
                             .modifier(
                                 MessageModifier(isMine: isMine)
                             )
+                            .contextMenu {
+                                Button {
+                                    messageStore.reportedMessage = message
+                                } label: {
+                                    Text("Report")
+                                    Image(systemName: "light.beacon.max")
+                                }
+                            }
                         Text(message.sentDateAsString)
                             .modifier(
                                 MessageTimeModifier()

--- a/GitSpace/Sources/Views/Chat/ChatRoom/MessageCell.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/MessageCell.swift
@@ -22,12 +22,19 @@ struct MessageCell : View {
         
         switch isMine {
         case true:
-            HStack(alignment: .bottom, spacing: 2) {
+            HStack (
+                alignment: .bottom,
+                spacing: 2
+            ) {
                 Spacer()
                 Text(message.sentDateAsString)
-                    .modifier(MessageTimeModifier())
+                    .modifier(
+                        MessageTimeModifier()
+                    )
                 Text(message.textContent)
-                    .modifier(MessageModifier(isMine: self.isMine))
+                    .modifier(
+                        MessageModifier(isMine: self.isMine)
+                    )
                     .contextMenu {
                         Button {
                             messageStore.deletedMessage = message
@@ -51,13 +58,26 @@ struct MessageCell : View {
                 }
                 
                 // UserName과 Message Bubble 부분
-                VStack (alignment: .leading, spacing: 6) {
-                    GSText.CustomTextView(style: .caption1, string: targetUserInfo.githubLogin)
-                    HStack(alignment: .bottom, spacing: 2) {
+                VStack (
+                    alignment: .leading,
+                    spacing: 6
+                ) {
+                    GSText.CustomTextView(
+                        style: .caption1,
+                        string: targetUserInfo.githubLogin
+                    )
+                    HStack (
+                        alignment: .bottom,
+                        spacing: 2
+                    ) {
                         Text(message.textContent)
-                            .modifier(MessageModifier(isMine: self.isMine))
+                            .modifier(
+                                MessageModifier(isMine: isMine)
+                            )
                         Text(message.sentDateAsString)
-                            .modifier(MessageTimeModifier())
+                            .modifier(
+                                MessageTimeModifier()
+                            )
                         Spacer()
                     }
                 }
@@ -89,30 +109,27 @@ struct ChatBubbleShape: Shape {
     let direction: Direction
     
     func path(in rect: CGRect) -> Path {
-        return (direction == .left) ? getLeftBubblePath(in: rect) : getRightBubblePath(in: rect)
-
+        return (direction == .left)
+        ? getLeftBubblePath(in: rect)
+        : getRightBubblePath(in: rect)
     }
     
     func getLeftBubblePath(in rect: CGRect) -> Path {
-        
-        let path = UIBezierPath(roundedRect: rect,
-                                byRoundingCorners: [.bottomRight, .bottomLeft, .topRight],
-                                cornerRadii: CGSize(width: 20, height: 20)
+        let path = UIBezierPath(
+            roundedRect: rect,
+            byRoundingCorners: [.bottomRight, .bottomLeft, .topRight],
+            cornerRadii: CGSize(width: 20, height: 20)
         )
-        
         return Path(path.cgPath)
     }
     
     func getRightBubblePath(in rect: CGRect) -> Path {
-        
-        let path = UIBezierPath(roundedRect: rect,
-                                byRoundingCorners: [.bottomRight, .bottomLeft, .topLeft],
-                                cornerRadii: CGSize(width: 20, height: 20)
+        let path = UIBezierPath(
+            roundedRect: rect,
+            byRoundingCorners: [.bottomRight, .bottomLeft, .topLeft],
+            cornerRadii: CGSize(width: 20, height: 20)
         )
-        
         return Path(path.cgPath)
-                                                    
-                                
     }
 }
 

--- a/GitSpace/Sources/Views/Chat/ChatRoom/MessageCell.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/MessageCell.swift
@@ -12,7 +12,9 @@ struct MessageCell : View {
     
     let message: Message
     let targetUserInfo: UserInfo
-    var isMine: Bool { return Utility.loginUserID == message.senderID }
+    var isMine: Bool {
+        Utility.loginUserID == message.senderID
+    }
     @EnvironmentObject var messageStore: MessageStore
     
     var body: some View {

--- a/GitSpace/Sources/Views/Chat/ChatRoom/MessageCell.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/MessageCell.swift
@@ -16,6 +16,7 @@ struct MessageCell : View {
         Utility.loginUserID == message.senderID
     }
     @EnvironmentObject var messageStore: MessageStore
+    @EnvironmentObject var githubAuthManager: GitHubAuthManager
     
     var body: some View {
         


### PR DESCRIPTION
## 개요 및 관련 이슈
- ChatRoomView에서 상대방 Message Cell을 ContextMenu로 신고할 수 있는 로직을 추가했습니다.
- #373

## 작업 사항
- 상대방 MessageCell에 ContextMenu 추가
- MessageViewModel에 신고 대상 Message 데이터를 담을 수 있는 reportedMessage 추가
- reportedMessage를 옵저빙해서 신고 sheet를 present 할 수 있는 로직 추가

## 주요 로직

1. 상대방 MessageCell의 ContextMenu로 report 버튼을 탭하면 해당 Message 객체가 messageViewModel의 reportedMessage에 전달됩니다.
2. ChatRoomView에서는 onChange로 reportedMessage의 변경을 감지합니다.
3. onChange 스코프 내부에서 신고 sheet를 present 하는 로직을 수행합니다.

### onChange를 거쳐서 해당 로직을 수행하는 이유
MessageCell 각각에 ContextMenu를 분리해서 작동하기 위해서는 ChatRoomView가 아닌 MessageCell 내부에서 ContextMenu를 구현해야합니다. 대신 이 방법을 사용할 경우 MessageCell 내부에서 직접 ChatRoomView로 특정 Message 객체를 전달할 방법이 없기 때문에 공통으로 참조하고 있는 MessageViewModel을 활용합니다. 

sheet와 같이 View 전체 영역에서 사용해야 하는 컴포넌트를 MessageCell에서 구현하게되면 Cell 영역 만큼만 sheet가 작동합니다. 그래서 sheet는 ChatRoomView에서 구현해야하고, 동시에 어떤 메세지가 신고의 대상이 되는지 신고 sheet에 전달해야하기 때문에 위와 같이 onChange를 통해 Message 객체를 전달하고 sheet를 작동하는 로직으로 수행됩니다.

### 메세지 셀 신고 버튼
```swift
Text(message.textContent)
    .modifier(
        MessageModifier(isMine: isMine)
    )
    .contextMenu {
        Button {
            messageStore.reportedMessage = message
        } label: {
            Text("Report")
            Image(systemName: "light.beacon.max")
        }
    }
```

### 신고 메세지 옵저빙에 대한 신고 sheet present

```swift
// 상대방 MessageCell ContextMenu에서 신고 버튼을 탭하면 수행되는 로직
.onChange(of: messageStore.reportedMessage?.id) { id in
            
    // TODO: 다혜님의 PR에 포함된 신고 sheet present 로직 구현
            
}
```