### PR TITLE
[Fix] ReportReasonDescription 열거형을 메서드로 변경했습니다.

### DIFF
--- a/GitSpace/Sources/Models/Report.swift
+++ b/GitSpace/Sources/Models/Report.swift
@@ -47,12 +47,4 @@ struct Report: Codable {
         }
         
     }
-    
-//    enum ReportReasonDescription: String, CaseIterable {
-//        case spammingDescription = "Spamming Description"
-//        case offensiveDescription = "Verbal Abuse, Offensive Language Description"
-//        case sexualDescription = "Sexual Description(Activity) Description"
-//        case cheatingDescription = "Cheating Description"
-//        case bullyingDescription = "Cyberbullying or Harassment Description"
-//    }
 }

--- a/GitSpace/Sources/Models/Report.swift
+++ b/GitSpace/Sources/Models/Report.swift
@@ -30,6 +30,22 @@ struct Report: Codable {
         case sexual = "Sexual Description(Activity)"
         case cheating = "Cheating"
         case bullying = "Cyberbullying or Harassment"
+        
+        func getDescription() -> String {
+            switch self {
+            case .spamming:
+                return "Spamming Description"
+            case .offensive:
+                return "Verbal Abuse, Offensive Language Description"
+            case .sexual:
+                return "Sexual Description(Activity) Description"
+            case .cheating:
+                return "Cheating Description"
+            case .bullying:
+                return "Cyberbullying or Harassment Description"
+            }
+        }
+        
     }
     
 //    enum ReportReasonDescription: String, CaseIterable {

--- a/GitSpace/Sources/Models/Report.swift
+++ b/GitSpace/Sources/Models/Report.swift
@@ -32,11 +32,11 @@ struct Report: Codable {
         case bullying = "Cyberbullying or Harassment"
     }
     
-    enum ReportReasonDescription: String, CaseIterable {
-        case spammingDescription = "Spamming Description"
-        case offensiveDescription = "Verbal Abuse, Offensive Language Description"
-        case sexualDescription = "Sexual Description(Activity) Description"
-        case cheatingDescription = "Cheating Description"
-        case bullyingDescription = "Cyberbullying or Harassment Description"
-    }
+//    enum ReportReasonDescription: String, CaseIterable {
+//        case spammingDescription = "Spamming Description"
+//        case offensiveDescription = "Verbal Abuse, Offensive Language Description"
+//        case sexualDescription = "Sexual Description(Activity) Description"
+//        case cheatingDescription = "Cheating Description"
+//        case bullyingDescription = "Cyberbullying or Harassment Description"
+//    }
 }

--- a/GitSpace/Sources/Views/Common/ReportView.swift
+++ b/GitSpace/Sources/Views/Common/ReportView.swift
@@ -99,8 +99,7 @@ Gitspace operation team will check and help you.
                     if (isReportReasonSelected && reportReasonNumber == index) {
                         GSText.CustomTextView(
                             style: .caption1,
-                            string:
-                                "\(Report.ReportReasonDescription.allCases[index].rawValue)"
+                            string: reason.getDescription()
                         )
                         .padding(EdgeInsets(top: 0, leading: 18, bottom: 10, trailing: 50))
                         .transition(


### PR DESCRIPTION
## 개요 및 관련 이슈
- ReportReasonDescription 열거형을 삭제하고 신고사유에 대한 설명을 리턴하는 메서드를 구현하였습니다.
- #378 

## 작업 사항
- ReportReasonDescription 열거형 삭제
- ReportReason 내부에 `getDescription` 메서드 생성
<br>

Report 구조체가 아닌, ReportReason 열거형 내부에 생성한 이유는 다음과 같습니다.
* 각 신고 사유에 대한 설명을 반환하는 함수이므로, ReportReason의 기능에 포함된다고 판단함.
* Report 구조체 내부 메서드로 구현할 경우, ReportReason의 각 케이스에 대한 분기 처리 구현이 어려움.
   * 이렇게 구현할 경우 호출시에 `Report().getDescription(-)`으로 해줘야 하며, ReportReason에 대한 각 케이스를 따로 전달해줘야 하는 번거로움이 발생함.
* ReportReason 열거형 내부 메서드로 생성할 경우, 메서드 내부에 self를 사용하여 쉽게 신고 사유별로 분기 처리 가능 


## 주요 로직
#### ReportReason > getDescription()
```diff
enum ReportReason: String, Codable, CaseIterable {
    case spamming = "Spamming"
    case offensive = "Verbal Abuse, Offensive Language"
    case sexual = "Sexual Description(Activity)"
    case cheating = "Cheating"
    case bullying = "Cyberbullying or Harassment"
    
+   func getDescription() -> String {
+       switch self {
+       case .spamming:
+           return "Spamming Description"
+       case .offensive:
+            return "Verbal Abuse, Offensive Language Description"
+       case .sexual:
+            return "Sexual Description(Activity) Description"
+       case .cheating:
+           return "Cheating Description"
+       case .bullying:
+           return "Cyberbullying or Harassment Description"
+       }
+   }
    
}
```