### PR TITLE
[Feat] Settings > Account 에서 차단한 유저 리스트를 보여주고, 차단 해제하는 기능을 추가했습니다.

### DIFF
--- a/GitSpace.xcodeproj/project.pbxproj
+++ b/GitSpace.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		3471460F2992217A00ED990C /* ReportGuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3471460E2992217A00ED990C /* ReportGuideView.swift */; };
 		347146122992253600ED990C /* GuideBlockSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 347146112992253600ED990C /* GuideBlockSection.swift */; };
 		347146142992254200ED990C /* BlockGuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 347146132992254200ED990C /* BlockGuideView.swift */; };
+		3476476229F160B400CCBD12 /* BlockedUsersListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3476476129F160B400CCBD12 /* BlockedUsersListView.swift */; };
 		348540EF299D5DFE00B738F9 /* TagGuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348540EE299D5DFE00B738F9 /* TagGuideView.swift */; };
 		348540F1299D5E7700B738F9 /* BlockListGuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348540F0299D5E7700B738F9 /* BlockListGuideView.swift */; };
 		348540F3299D5E9E00B738F9 /* AfterBlockGuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348540F2299D5E9E00B738F9 /* AfterBlockGuideView.swift */; };
@@ -242,6 +243,7 @@
 		3471460E2992217A00ED990C /* ReportGuideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportGuideView.swift; sourceTree = "<group>"; };
 		347146112992253600ED990C /* GuideBlockSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuideBlockSection.swift; sourceTree = "<group>"; };
 		347146132992254200ED990C /* BlockGuideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockGuideView.swift; sourceTree = "<group>"; };
+		3476476129F160B400CCBD12 /* BlockedUsersListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedUsersListView.swift; sourceTree = "<group>"; };
 		348540EE299D5DFE00B738F9 /* TagGuideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagGuideView.swift; sourceTree = "<group>"; };
 		348540F0299D5E7700B738F9 /* BlockListGuideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockListGuideView.swift; sourceTree = "<group>"; };
 		348540F2299D5E9E00B738F9 /* AfterBlockGuideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AfterBlockGuideView.swift; sourceTree = "<group>"; };
@@ -435,8 +437,8 @@
 			isa = PBXGroup;
 			children = (
 				0BF5E35D2977AD5600F3673C /* SetMainView.swift */,
-				34277360299495C000818816 /* SetAccountView.swift */,
 				34277362299495EC00818816 /* SetPrivacySafetyView.swift */,
+				3476476029F1603900CCBD12 /* Account */,
 				342773512993E13A00818816 /* AppSettings */,
 				342773522993E14F00818816 /* Legal */,
 			);
@@ -534,6 +536,15 @@
 				348540F2299D5E9E00B738F9 /* AfterBlockGuideView.swift */,
 			);
 			path = GuideBlock;
+			sourceTree = "<group>";
+		};
+		3476476029F1603900CCBD12 /* Account */ = {
+			isa = PBXGroup;
+			children = (
+				34277360299495C000818816 /* SetAccountView.swift */,
+				3476476129F160B400CCBD12 /* BlockedUsersListView.swift */,
+			);
+			path = Account;
 			sourceTree = "<group>";
 		};
 		680C199D29937C8B009AF5D5 /* Auth */ = {
@@ -1021,6 +1032,7 @@
 				22958CAD29C752B000786357 /* ReadmeLoadingView.swift in Sources */,
 				704D160F29992FF9009206BD /* String+.swift in Sources */,
 				6E128D6529A3BDFF0004AEC8 /* ImageCacheManager.swift in Sources */,
+				3476476229F160B400CCBD12 /* BlockedUsersListView.swift in Sources */,
 				6E70333E29890ADE00FFC018 /* ChatListSection.swift in Sources */,
 				6E08402329839BD200F51169 /* Utility.swift in Sources */,
 				68E95FC72976D48C002E65AD /* StarredView.swift in Sources */,

--- a/GitSpace.xcodeproj/project.pbxproj
+++ b/GitSpace.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		347146122992253600ED990C /* GuideBlockSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 347146112992253600ED990C /* GuideBlockSection.swift */; };
 		347146142992254200ED990C /* BlockGuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 347146132992254200ED990C /* BlockGuideView.swift */; };
 		3476476229F160B400CCBD12 /* BlockedUsersListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3476476129F160B400CCBD12 /* BlockedUsersListView.swift */; };
+		3476476429F16DB800CCBD12 /* BlockedUsersListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3476476329F16DB800CCBD12 /* BlockedUsersListCell.swift */; };
 		348540EF299D5DFE00B738F9 /* TagGuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348540EE299D5DFE00B738F9 /* TagGuideView.swift */; };
 		348540F1299D5E7700B738F9 /* BlockListGuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348540F0299D5E7700B738F9 /* BlockListGuideView.swift */; };
 		348540F3299D5E9E00B738F9 /* AfterBlockGuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348540F2299D5E9E00B738F9 /* AfterBlockGuideView.swift */; };
@@ -244,6 +245,7 @@
 		347146112992253600ED990C /* GuideBlockSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuideBlockSection.swift; sourceTree = "<group>"; };
 		347146132992254200ED990C /* BlockGuideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockGuideView.swift; sourceTree = "<group>"; };
 		3476476129F160B400CCBD12 /* BlockedUsersListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedUsersListView.swift; sourceTree = "<group>"; };
+		3476476329F16DB800CCBD12 /* BlockedUsersListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedUsersListCell.swift; sourceTree = "<group>"; };
 		348540EE299D5DFE00B738F9 /* TagGuideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagGuideView.swift; sourceTree = "<group>"; };
 		348540F0299D5E7700B738F9 /* BlockListGuideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockListGuideView.swift; sourceTree = "<group>"; };
 		348540F2299D5E9E00B738F9 /* AfterBlockGuideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AfterBlockGuideView.swift; sourceTree = "<group>"; };
@@ -543,6 +545,7 @@
 			children = (
 				34277360299495C000818816 /* SetAccountView.swift */,
 				3476476129F160B400CCBD12 /* BlockedUsersListView.swift */,
+				3476476329F16DB800CCBD12 /* BlockedUsersListCell.swift */,
 			);
 			path = Account;
 			sourceTree = "<group>";
@@ -959,6 +962,7 @@
 				708E70E92997E01F008BC975 /* SendKnockView.swift in Sources */,
 				2205F241299CCBF900B2643D /* FollowerViewModel.swift in Sources */,
 				6E0F9595298CF5F8000FE529 /* GSTextEditor.swift in Sources */,
+				3476476429F16DB800CCBD12 /* BlockedUsersListCell.swift in Sources */,
 				70DB32B22989FAB0004E82AD /* Message.swift in Sources */,
 				700A11D2299737F4008C94C7 /* AppDelegate+Firebase.swift in Sources */,
 				22E9ECF1299BA78400D5A9C6 /* UIScreen+.swift in Sources */,

--- a/GitSpace.xcodeproj/project.pbxproj
+++ b/GitSpace.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		347146142992254200ED990C /* BlockGuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 347146132992254200ED990C /* BlockGuideView.swift */; };
 		3476476229F160B400CCBD12 /* BlockedUsersListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3476476129F160B400CCBD12 /* BlockedUsersListView.swift */; };
 		3476476429F16DB800CCBD12 /* BlockedUsersListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3476476329F16DB800CCBD12 /* BlockedUsersListCell.swift */; };
+		3477D62529F5631F001EA572 /* BlockedUsersListSkeletonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3477D62429F5631F001EA572 /* BlockedUsersListSkeletonView.swift */; };
 		348540EF299D5DFE00B738F9 /* TagGuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348540EE299D5DFE00B738F9 /* TagGuideView.swift */; };
 		348540F1299D5E7700B738F9 /* BlockListGuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348540F0299D5E7700B738F9 /* BlockListGuideView.swift */; };
 		348540F3299D5E9E00B738F9 /* AfterBlockGuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348540F2299D5E9E00B738F9 /* AfterBlockGuideView.swift */; };
@@ -246,6 +247,7 @@
 		347146132992254200ED990C /* BlockGuideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockGuideView.swift; sourceTree = "<group>"; };
 		3476476129F160B400CCBD12 /* BlockedUsersListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedUsersListView.swift; sourceTree = "<group>"; };
 		3476476329F16DB800CCBD12 /* BlockedUsersListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedUsersListCell.swift; sourceTree = "<group>"; };
+		3477D62429F5631F001EA572 /* BlockedUsersListSkeletonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedUsersListSkeletonView.swift; sourceTree = "<group>"; };
 		348540EE299D5DFE00B738F9 /* TagGuideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagGuideView.swift; sourceTree = "<group>"; };
 		348540F0299D5E7700B738F9 /* BlockListGuideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockListGuideView.swift; sourceTree = "<group>"; };
 		348540F2299D5E9E00B738F9 /* AfterBlockGuideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AfterBlockGuideView.swift; sourceTree = "<group>"; };
@@ -546,6 +548,7 @@
 				34277360299495C000818816 /* SetAccountView.swift */,
 				3476476129F160B400CCBD12 /* BlockedUsersListView.swift */,
 				3476476329F16DB800CCBD12 /* BlockedUsersListCell.swift */,
+				3477D62429F5631F001EA572 /* BlockedUsersListSkeletonView.swift */,
 			);
 			path = Account;
 			sourceTree = "<group>";
@@ -1041,6 +1044,7 @@
 				6E08402329839BD200F51169 /* Utility.swift in Sources */,
 				68E95FC72976D48C002E65AD /* StarredView.swift in Sources */,
 				7095CFA4297EB913000F2BF6 /* Color+.swift in Sources */,
+				3477D62529F5631F001EA572 /* BlockedUsersListSkeletonView.swift in Sources */,
 				0B87BA52298CCD9E006B80D3 /* GSText.swift in Sources */,
 				6E38C6042991EF380043A8BB /* ChatListCell.swift in Sources */,
 				680C944529B9F2A300720718 /* KeyChainManager.swift in Sources */,

--- a/GitSpace/GitSpaceApp.swift
+++ b/GitSpace/GitSpaceApp.swift
@@ -31,6 +31,7 @@ struct GitSpaceApp: App {
                 .environmentObject(FollowerViewModel(service: GitHubService()))
                 .environmentObject(tabBarRouter)
 				.environmentObject(pushNotificationManager)
+                .environmentObject(BlockedUsers())
 				.onAppear {
 					UIApplication.shared.applicationIconBadgeNumber = 0
 				}

--- a/GitSpace/Sources/Models/UserInfo.swift
+++ b/GitSpace/Sources/Models/UserInfo.swift
@@ -9,7 +9,7 @@
 
 import Foundation
 
-struct UserInfo : Identifiable, Codable {
+struct UserInfo : Identifiable, Codable, Equatable {
     // MARK: -Firestore Properties
     let id: String                  // 유저 ID (Firebase Auth UID)
     let createdDate: Date           // 유저 생성일시

--- a/GitSpace/Sources/Network/Interface/Blockable.swift
+++ b/GitSpace/Sources/Network/Interface/Blockable.swift
@@ -64,6 +64,7 @@ extension Blockable {
         }
     }
     
+    @discardableResult
     func unblockTargetUser(
         in currentUser: UserInfo,
         with targetUser: UserInfo

--- a/GitSpace/Sources/ViewModels/GitHubAuthManager.swift
+++ b/GitSpace/Sources/ViewModels/GitHubAuthManager.swift
@@ -178,7 +178,7 @@ final class GitHubAuthManager: ObservableObject {
      
      - Returns: FBUser의 프로퍼티를 통해 생성한 GithubUser 인스턴스
      */
-    private func getGithubUser(FBUser: UserInfo) -> GithubUser {
+    func getGithubUser(FBUser: UserInfo) -> GithubUser {
         return .init(id: FBUser.githubID,
                      login: FBUser.githubLogin,
                      name: FBUser.githubName,

--- a/GitSpace/Sources/Views/Settings/Account/BlockedUsersListCell.swift
+++ b/GitSpace/Sources/Views/Settings/Account/BlockedUsersListCell.swift
@@ -65,8 +65,7 @@ struct BlockedUsersListCell: View, Blockable {
 }
 
 struct BlockedUsersListCell_Previews: PreviewProvider {
-    
     static var previews: some View {
-        BlockedUsersListCell(targetUser: GithubUser(id: 123, login: "guguhanogu", name: "HanHo Choi", email: "", avatar_url: "https://avatars.githubusercontent.com/u/64696968?v=4", bio: "", company: "", location: "", blog: "", public_repos: 123, followers: 123, following: 123))
+        BlockedUsersListCell(userInfo: UserInfo(id: "0kOWGBrrDeZXzgPIN4mXptYTj0l1", createdDate: Date(), deviceToken: "", blockedUserIDs: [""], githubID: 19788294, githubLogin: "jekyun-park", githubName: "jegyun", githubEmail: "", avatar_url: "https://avatars.githubusercontent.com/u/19788294?v=4", bio: "", company: "", location: "", blog: "", public_repos: 9, followers: 47, following: 50), gitHubUser: GithubUser(id: 19788294, login: "jekyun-park", name: "jegyun", email: "parkjekyun@gmail.com", avatar_url: "https://avatars.githubusercontent.com/u/19788294?v=4", bio: "", company: "Hanyang University, ERICA", location: "Suwon", blog: "https://jegyun97.tistory.com/", public_repos: 9, followers: 47, following: 50))
     }
 }

--- a/GitSpace/Sources/Views/Settings/Account/BlockedUsersListCell.swift
+++ b/GitSpace/Sources/Views/Settings/Account/BlockedUsersListCell.swift
@@ -13,23 +13,26 @@ struct BlockedUsersListCell: View, Blockable {
         GSCanvas.CustomCanvasView.init(style: .primary, content: {
             HStack(spacing: 15) {
                 
-                NavigationLink(destination: TargetUserProfileView(user: targetUser)) {
-                    /* 유저 프로필 이미지 */
-                    GithubProfileImage(urlStr: targetUser.avatar_url, size: 40)
-                }
-                
-                VStack(alignment: .leading) {
-                    /* 유저네임 */
-                    GSText.CustomTextView(
-                        style: .title3,
-                        string: targetUser.name ?? targetUser.login)
+                NavigationLink(destination: TargetUserProfileView(user: gitHubUser)) {
                     
-                    /* 유저ID */
-                    GSText.CustomTextView(
-                        style: .sectionTitle,
-                        string: targetUser.login)
-                } // VStack
-                .multilineTextAlignment(.leading)
+                    HStack(spacing: 15) {
+                        /* 유저 프로필 이미지 */
+                        GithubProfileImage(urlStr: gitHubUser.avatar_url, size: 40)
+                        
+                        VStack(alignment: .leading) {
+                            /* 유저네임 */
+                            GSText.CustomTextView(
+                                style: .title3,
+                                string: gitHubUser.name ?? gitHubUser.login)
+                            
+                            /* 유저ID */
+                            GSText.CustomTextView(
+                                style: .sectionTitle,
+                                string: gitHubUser.login)
+                        } // VStack
+                        .multilineTextAlignment(.leading)
+                    }
+                }
                 
                 Spacer()
                 

--- a/GitSpace/Sources/Views/Settings/Account/BlockedUsersListCell.swift
+++ b/GitSpace/Sources/Views/Settings/Account/BlockedUsersListCell.swift
@@ -44,6 +44,7 @@ struct BlockedUsersListCell: View, Blockable {
                 }
             } // HStack
         }) // GSCanvas
+        .padding(.horizontal, 10)
     }
 }
 

--- a/GitSpace/Sources/Views/Settings/Account/BlockedUsersListCell.swift
+++ b/GitSpace/Sources/Views/Settings/Account/BlockedUsersListCell.swift
@@ -7,9 +7,7 @@
 
 import SwiftUI
 
-struct BlockedUsersListCell: View {
-    
-    let targetUser: GithubUser
+struct BlockedUsersListCell: View, Blockable {
     
     var body: some View {
         GSCanvas.CustomCanvasView.init(style: .primary, content: {

--- a/GitSpace/Sources/Views/Settings/Account/BlockedUsersListCell.swift
+++ b/GitSpace/Sources/Views/Settings/Account/BlockedUsersListCell.swift
@@ -9,6 +9,13 @@ import SwiftUI
 
 struct BlockedUsersListCell: View, Blockable {
     
+    @EnvironmentObject var gitHubAuthManager: GitHubAuthManager
+    @EnvironmentObject var userInfoManager: UserStore
+    @EnvironmentObject var blockedUsers: BlockedUsers
+        
+    let userInfo: UserInfo
+    let gitHubUser: GithubUser
+        
     var body: some View {
         GSCanvas.CustomCanvasView.init(style: .primary, content: {
             HStack(spacing: 15) {

--- a/GitSpace/Sources/Views/Settings/Account/BlockedUsersListCell.swift
+++ b/GitSpace/Sources/Views/Settings/Account/BlockedUsersListCell.swift
@@ -1,0 +1,20 @@
+//
+//  BlockedUsersListCell.swift
+//  GitSpace
+//
+//  Created by 최한호 on 2023/04/20.
+//
+
+import SwiftUI
+
+struct BlockedUsersListCell: View {
+    var body: some View {
+        Text("Hello, World!")
+    }
+}
+
+struct BlockedUsersListCell_Previews: PreviewProvider {
+    static var previews: some View {
+        BlockedUsersListCell()
+    }
+}

--- a/GitSpace/Sources/Views/Settings/Account/BlockedUsersListCell.swift
+++ b/GitSpace/Sources/Views/Settings/Account/BlockedUsersListCell.swift
@@ -46,6 +46,15 @@ struct BlockedUsersListCell: View, Blockable {
                 GSButton.CustomButtonView(
                     style: .secondary(isDisabled: true)
                 ) {
+                    Task {
+                        if let currentUser = userInfoManager.currentUser {
+                            let _ = try await unblockTargetUser(in: currentUser, with: userInfo)
+                            
+                            blockedUsers.blockedUserList.removeAll {
+                                $0 == (userInfo: userInfo, gitHubUser: gitHubUser)
+                            }
+                        }
+                    }
                 } label: {
                     Text("**Unblock**")
                 }

--- a/GitSpace/Sources/Views/Settings/Account/BlockedUsersListCell.swift
+++ b/GitSpace/Sources/Views/Settings/Account/BlockedUsersListCell.swift
@@ -8,13 +8,51 @@
 import SwiftUI
 
 struct BlockedUsersListCell: View {
+    
+    let targetUser: GithubUser
+    
     var body: some View {
-        Text("Hello, World!")
+        GSCanvas.CustomCanvasView.init(style: .primary, content: {
+            HStack(spacing: 15) {
+                
+                NavigationLink(destination: TargetUserProfileView(user: targetUser)) {
+                    /* 유저 프로필 이미지 */
+                    GithubProfileImage(urlStr: targetUser.avatar_url, size: 40)
+                }
+                
+                VStack(alignment: .leading) {
+                    /* 유저네임 */
+                    GSText.CustomTextView(
+                        style: .title3,
+                        string: targetUser.name ?? targetUser.login)
+                    
+                    /* 유저ID */
+                    GSText.CustomTextView(
+                        style: .sectionTitle,
+                        string: targetUser.login)
+                } // VStack
+                .multilineTextAlignment(.leading)
+                
+                Spacer()
+                
+                
+                GSButton.CustomButtonView(
+                    style: .tag(
+                        isAppliedInView: true
+                    )
+                ) {
+                    
+                } label: {
+                    Text("**Unblock**")
+                }
+            } // HStack
+        }) // GSCanvas
     }
 }
 
 struct BlockedUsersListCell_Previews: PreviewProvider {
+    
     static var previews: some View {
-        BlockedUsersListCell()
+        BlockedUsersListCell(targetUser: GithubUser(id: 123, login: "guguhanogu", name: "HanHo Choi", email: "", avatar_url: "https://avatars.githubusercontent.com/u/64696968?v=4", bio: "", company: "", location: "", blog: "", public_repos: 123, followers: 123, following: 123))
     }
 }

--- a/GitSpace/Sources/Views/Settings/Account/BlockedUsersListCell.swift
+++ b/GitSpace/Sources/Views/Settings/Account/BlockedUsersListCell.swift
@@ -36,13 +36,9 @@ struct BlockedUsersListCell: View, Blockable {
                 
                 Spacer()
                 
-                
                 GSButton.CustomButtonView(
-                    style: .tag(
-                        isAppliedInView: true
-                    )
+                    style: .secondary(isDisabled: true)
                 ) {
-                    
                 } label: {
                     Text("**Unblock**")
                 }

--- a/GitSpace/Sources/Views/Settings/Account/BlockedUsersListSkeletonView.swift
+++ b/GitSpace/Sources/Views/Settings/Account/BlockedUsersListSkeletonView.swift
@@ -1,0 +1,21 @@
+//
+//  BlockedUsersListSkeletonView.swift
+//  GitSpace
+//
+//  Created by 최한호 on 2023/04/23.
+//
+
+import SwiftUI
+
+struct BlockedUsersListSkeletonView: View {
+    
+    
+    var body: some View {
+    }
+}
+
+struct BlockedUsersListSkeletonView_Previews: PreviewProvider {
+    static var previews: some View {
+        BlockedUsersListSkeletonView()
+    }
+}

--- a/GitSpace/Sources/Views/Settings/Account/BlockedUsersListSkeletonView.swift
+++ b/GitSpace/Sources/Views/Settings/Account/BlockedUsersListSkeletonView.swift
@@ -9,8 +9,46 @@ import SwiftUI
 
 struct BlockedUsersListSkeletonView: View {
     
+    @State var opacity: CGFloat = 0.3
     
     var body: some View {
+        VStack {
+            ForEach(0..<8) { _ in
+                GSCanvas.CustomCanvasView.init(style: .primary, content: {
+                    HStack(spacing: 15) {
+                        /* 유저 프로필 이미지 */
+                        Image("ProfilePlaceholder")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .clipShape(Circle())
+                            .frame(width: 40)
+                        
+                        VStack(alignment: .leading, spacing: 5) {
+                            /* 유저네임 */
+                            GSText.CustomTextView(
+                                style: .caption1,
+                                string: String(repeating:" ", count: 40))
+                            .modifier(BlinkingSkeletonModifier(opacity: opacity, shouldShow: true))
+                            
+                            /* 유저ID */
+                            GSText.CustomTextView(
+                                style: .caption1,
+                                string: String(repeating:" ", count: 25))
+                            .modifier(BlinkingSkeletonModifier(opacity: opacity, shouldShow: true))
+                        } // VStack
+                        .multilineTextAlignment(.leading)
+                        
+                        Spacer()
+                    } // HStack
+                }) // GSCanvas
+                .padding(.horizontal, 10)
+            } // ForEach
+        }
+        .task {
+            withAnimation(.linear(duration: 0.5).repeatForever(autoreverses: true)){
+                self.opacity = opacity == 0.3 ? 1.0 : 0.3
+            }
+        }
     }
 }
 

--- a/GitSpace/Sources/Views/Settings/Account/BlockedUsersListView.swift
+++ b/GitSpace/Sources/Views/Settings/Account/BlockedUsersListView.swift
@@ -39,6 +39,15 @@ struct BlockedUsersListView: View {
     var body: some View {
         VStack {
             if isLoaded {
+                } else {
+                    VStack {
+                        Spacer()
+                        GSText.CustomTextView(
+                            style: .description2,
+                            string: "You haven't blocked anyone.")
+                        Spacer()
+                    }
+                }
             } else {
                 BlockedUsersListSkeletonView()
             }

--- a/GitSpace/Sources/Views/Settings/Account/BlockedUsersListView.swift
+++ b/GitSpace/Sources/Views/Settings/Account/BlockedUsersListView.swift
@@ -8,7 +8,9 @@
 import SwiftUI
 
 struct BlockedUsersListView: View {
-    var body: some View {
+    
+    @EnvironmentObject var gitHubAuthManager: GitHubAuthManager
+    @EnvironmentObject var userInfoManager: UserStore
     @State var isLoaded: Bool = false
     
     func convertUserInfo() async {

--- a/GitSpace/Sources/Views/Settings/Account/BlockedUsersListView.swift
+++ b/GitSpace/Sources/Views/Settings/Account/BlockedUsersListView.swift
@@ -6,11 +6,13 @@
 //
 
 import SwiftUI
+import Combine
 
 struct BlockedUsersListView: View {
     
     @EnvironmentObject var gitHubAuthManager: GitHubAuthManager
     @EnvironmentObject var userInfoManager: UserStore
+    @EnvironmentObject var blockedUsers: BlockedUsers
     @State var isLoaded: Bool = false
     
     func convertUserInfo() async {
@@ -75,6 +77,8 @@ struct BlockedUsersListView: View {
     }
 }
 
+class BlockedUsers: ObservableObject {
+    @Published var blockedUserList: [(userInfo: UserInfo, gitHubUser: GithubUser)] = []
 }
 
 struct BlockedUsersListView_Previews: PreviewProvider {

--- a/GitSpace/Sources/Views/Settings/Account/BlockedUsersListView.swift
+++ b/GitSpace/Sources/Views/Settings/Account/BlockedUsersListView.swift
@@ -1,0 +1,23 @@
+//
+//  BlockedUsersListView.swift
+//  GitSpace
+//
+//  Created by 최한호 on 2023/04/20.
+//
+
+import SwiftUI
+
+struct BlockedUsersListView: View {
+    var body: some View {
+        
+        ScrollView {
+            
+        }
+    }
+}
+
+struct BlockedUsersListView_Previews: PreviewProvider {
+    static var previews: some View {
+        BlockedUsersListView()
+    }
+}

--- a/GitSpace/Sources/Views/Settings/Account/BlockedUsersListView.swift
+++ b/GitSpace/Sources/Views/Settings/Account/BlockedUsersListView.swift
@@ -39,6 +39,18 @@ struct BlockedUsersListView: View {
     var body: some View {
         VStack {
             if isLoaded {
+                if !blockedUsers.blockedUserList.isEmpty {
+                    ScrollView {
+                        ForEach(blockedUsers.blockedUserList, id: \.userInfo.id) { blockedUser in
+                            BlockedUsersListCell(
+                                userInfo: blockedUser.userInfo,
+                                gitHubUser: blockedUser.gitHubUser
+                            )
+                        }
+                    } // ScrollView
+                    .refreshable {
+                        await convertUserInfo()
+                    }
                 } else {
                     VStack {
                         Spacer()

--- a/GitSpace/Sources/Views/Settings/Account/BlockedUsersListView.swift
+++ b/GitSpace/Sources/Views/Settings/Account/BlockedUsersListView.swift
@@ -9,9 +9,29 @@ import SwiftUI
 
 struct BlockedUsersListView: View {
     var body: some View {
+    func convertUserInfo() async {
+        
+        withAnimation(.easeInOut) {
+            isLoaded = false
+        }
         
         ScrollView {
+        if let currentUser = await userInfoManager.requestUserInfoWithID(userID: userInfoManager.currentUser?.id ?? "") {
             
+            for someUser in currentUser.blockedUserIDs {
+                if let userInfo = await UserStore.requestAndReturnUser(userID: someUser) {
+                    let gitHubUser = gitHubAuthManager.getGithubUser(FBUser: userInfo)
+                    let blockedUser: (userInfo: UserInfo, gitHubUser: GithubUser) = (userInfo, gitHubUser)
+                    
+                    if !blockedUsers.blockedUserList.contains(where: { $0.userInfo.id == userInfo.id }) {
+                        blockedUsers.blockedUserList.append(blockedUser)
+                    }
+                }
+            }
+        }
+        
+        withAnimation(.easeInOut) {
+            isLoaded = true
         }
     }
 }

--- a/GitSpace/Sources/Views/Settings/Account/BlockedUsersListView.swift
+++ b/GitSpace/Sources/Views/Settings/Account/BlockedUsersListView.swift
@@ -66,6 +66,15 @@ struct BlockedUsersListView: View {
                 BlockedUsersListSkeletonView()
             }
         } //VStack
+        .navigationBarTitle("Blocked users", displayMode: .inline)
+        .onViewDidLoad {
+            Task {
+                await convertUserInfo()
+            }
+        }
+    }
+}
+
 }
 
 struct BlockedUsersListView_Previews: PreviewProvider {

--- a/GitSpace/Sources/Views/Settings/Account/BlockedUsersListView.swift
+++ b/GitSpace/Sources/Views/Settings/Account/BlockedUsersListView.swift
@@ -9,13 +9,14 @@ import SwiftUI
 
 struct BlockedUsersListView: View {
     var body: some View {
+    @State var isLoaded: Bool = false
+    
     func convertUserInfo() async {
         
         withAnimation(.easeInOut) {
             isLoaded = false
         }
         
-        ScrollView {
         if let currentUser = await userInfoManager.requestUserInfoWithID(userID: userInfoManager.currentUser?.id ?? "") {
             
             for someUser in currentUser.blockedUserIDs {
@@ -34,6 +35,14 @@ struct BlockedUsersListView: View {
             isLoaded = true
         }
     }
+    
+    var body: some View {
+        VStack {
+            if isLoaded {
+            } else {
+                BlockedUsersListSkeletonView()
+            }
+        } //VStack
 }
 
 struct BlockedUsersListView_Previews: PreviewProvider {

--- a/GitSpace/Sources/Views/Settings/Account/SetAccountView.swift
+++ b/GitSpace/Sources/Views/Settings/Account/SetAccountView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct SetAccountView: View {
     
     @EnvironmentObject var gitHubAuthManager: GitHubAuthManager
+    @EnvironmentObject var blockedUsers: BlockedUsers
     @State private var showingLogoutAlert = false
     @State private var showingDeleteAccountAlert = false
     

--- a/GitSpace/Sources/Views/Settings/Account/SetAccountView.swift
+++ b/GitSpace/Sources/Views/Settings/Account/SetAccountView.swift
@@ -37,7 +37,7 @@ struct SetAccountView: View {
                     HStack {
                         Text("Blocked users")
                         Spacer()
-                        Text("\(0)")
+                        Text("\(blockedUsers.blockedUserList.count)")
                             .foregroundColor(.gsLightGray2)
                     }
                 }

--- a/GitSpace/Sources/Views/Settings/Account/SetAccountView.swift
+++ b/GitSpace/Sources/Views/Settings/Account/SetAccountView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct SetAccountView: View {
     
-    @EnvironmentObject var GitHubAuthManager: GitHubAuthManager
+    @EnvironmentObject var gitHubAuthManager: GitHubAuthManager
     @State private var showingLogoutAlert = false
     @State private var showingDeleteAccountAlert = false
     
@@ -20,7 +20,7 @@ struct SetAccountView: View {
                 HStack {
                     Text("Username")
                     Spacer()
-                    Text("\(GitHubAuthManager.authenticatedUser?.login ?? "")")
+                    Text("\(gitHubAuthManager.authenticatedUser?.login ?? "")")
                         .foregroundColor(.gsLightGray2)
                 }
             } header: {
@@ -65,20 +65,20 @@ struct SetAccountView: View {
         .navigationBarTitle("Account", displayMode: .inline)
         .alert("Logout", isPresented: $showingLogoutAlert) {
               Button("Logout", role: .destructive) {
-                  GitHubAuthManager.signOut()
+                  gitHubAuthManager.signOut()
               }
         } message: {
-            Text("Logout from ") + Text("@\(GitHubAuthManager.authenticatedUser?.login ?? "") ").bold() + Text("account.")
+            Text("Logout from ") + Text("@\(gitHubAuthManager.authenticatedUser?.login ?? "") ").bold() + Text("account.")
         }
         .alert("Delete Account", isPresented: $showingDeleteAccountAlert) {
               Button("Delete", role: .destructive) {
                   Task {
-                      await GitHubAuthManager.deleteCurrentUser()
-                      await GitHubAuthManager.withdrawal()
+                      await gitHubAuthManager.deleteCurrentUser()
+                      await gitHubAuthManager.withdrawal()
                   }
               }
         } message: {
-            Text("@\(GitHubAuthManager.authenticatedUser?.login ?? "") ").bold() + Text("account has been deleted.")
+            Text("@\(gitHubAuthManager.authenticatedUser?.login ?? "") ").bold() + Text("account has been deleted.")
         }
     }
 }

--- a/GitSpace/Sources/Views/Settings/Account/SetAccountView.swift
+++ b/GitSpace/Sources/Views/Settings/Account/SetAccountView.swift
@@ -29,18 +29,18 @@ struct SetAccountView: View {
             
             // MARK: Blocked Users
             /// 차단한 유저 리스트
-//            Section {
-//                NavigationLink {
-//
-//                } label: {
-//                    HStack {
-//                        Text("Blocked Users")
-//                        Spacer()
-//                        Text("\(0)")
-//                            .foregroundColor(.gsLightGray2)
-//                    }
-//                }
-//            } // Section
+            Section {
+                NavigationLink {
+                    BlockedUsersListView()
+                } label: {
+                    HStack {
+                        Text("Blocked users")
+                        Spacer()
+                        Text("\(0)")
+                            .foregroundColor(.gsLightGray2)
+                    }
+                }
+            } // Section
             
             // MARK: Logout / Delete Account
             /// 로그아웃 / 계정 삭제

--- a/GitSpace/Sources/Views/Settings/SetMainView.swift
+++ b/GitSpace/Sources/Views/Settings/SetMainView.swift
@@ -26,7 +26,6 @@ struct SetMainView: View {
         }
     }
     
-    
     var body: some View {
             List {
                 // MARK: - USER SETTINGS
@@ -201,7 +200,6 @@ struct SetMainView: View {
                 }
             } // List
             .navigationBarTitle("Settings", displayMode: .inline)
-        
     } // body
 }
 


### PR DESCRIPTION
## 개요 및 관련 이슈
- Settings > Account 에서 차단한 유저 리스트를 보여주고, 차단 해제하는 기능을 추가했습니다.
- #368 

## 작업 사항
차단한 유저 리스트를 보여주고, 차단을 해제하는 기능을 추가했습니다.

### View
- `BlockedUsersListView`: 차단한 유저의 리스트를 보여주는 뷰
- `BlockedUsersListCell`: 차단한 유저(Cell)
- `BlockedUsersListSkeletonView`: `convertUserInfo()` 메서드가 실행할 동안 보여줄 스켈레톤 뷰
### Method
- **`convertUserInfo()`**:
`currentUser.blockedUserIDs`에서 `UserID`를 받아와 `gitHubUser`와 `UserInfo`로 변환하여
`BlockedUsers.blockedUserList`에 추가해주는 메서드 입니다.
주요 로직은 다음과 같습니다. 설명이 필요한 부분에 각주를 달았습니다.
```swift
func convertUserInfo() async {
        /// 메서드가 실행되면 isLoaded를 false로 바꾸며,
        /// 메서드가 실행되는 동안 스켈레톤 뷰가 노출됩니다.
        withAnimation(.easeInOut) {
            isLoaded = false
        }
        
        /// requestUserInfoWithID를 통해 현재 유저 정보를 갱신합니다.
        if let currentUser = await userInfoManager.requestUserInfoWithID(
                userID: userInfoManager.currentUser?.id ?? "") {
            
            /// 현재 유저의 blockedUserIDs에서 id값을 하나씩 받아옵니다.
            for someUser in currentUser.blockedUserIDs {
                /// 받아온 id값으로 UserInfo와 GitHubUser로 변환합니다.
                if let userInfo = await UserStore.requestAndReturnUser(userID: someUser) {
                    let gitHubUser
                        = gitHubAuthManager.getGithubUser(FBUser: userInfo)
                    /// 변환한 UserInfo와 GitHubUser를 tuple 형태로 만들어
                    let blockedUser: (userInfo: UserInfo, gitHubUser: GithubUser)
                        = (userInfo, gitHubUser)
                    /// blockedUsers.blockedUserList에 값을 추가합니다.
                    if !blockedUsers.blockedUserList.contains(
                                where: { $0.userInfo.id == userInfo.id }) {
                        blockedUsers.blockedUserList.append(blockedUser)
                    }
                }
            }
        }
        
        /// 메서드 작업이 완료되면, isLoaded를 true로 바꿉니다.
        withAnimation(.easeInOut) {
            isLoaded = true
        }
    }
```
### UserInfo와 GitHubUser를 tuple 형태로 배열에 담은 이유

| BlockedUsersListView >. BlockedUsersListCell |
|:-----------------------------------------------:|
| <img width="300" alt="image" src="https://cdn.discordapp.com/attachments/1065922258364796938/1100318544119468114/image0.jpg"> |

- 왼쪽의 사용자 프로필, 이름을 탭하면 `TargetUserProfileView`로 이동할 수 있습니다.
이때 `TargetUserProfileView`에서는 `GithubUser`가 필요합니다.
- 오른쪽의 **Unblock** 버튼을 통해 `unblockTargetUser` 메서드를 실행할 수 있습니다.
이때 `UserInfo`가 필요합니다.
- 두 타입이 모두 필요해 `BlockedUsers.blockedUserList`에 Tuple 형태로 담게 되었습니다.

### BlockedUsers
```swift
@EnvironmentObject var blockedUsers: BlockedUsers

class BlockedUsers: ObservableObject {
    @Published var blockedUserList: [(userInfo: UserInfo, gitHubUser: GithubUser)] = []
}
```
- BlockedUsers 배열을 사용하는 뷰는 총 3곳 입니다.
  - `SetAccountView`
  - `BlockedUserListView` 
  - `BlockedUserListCell`
  
  세 곳에서 공통된 배열에 접근이 용이하도록 하기 위해 ObservableObject로 만들게 되었습니다.

### UserInfo의 Equtable 프로토콜 채택
- BlockedUsers 배열에 다음과 같이 값을 추가합니다.

```swift
!blockedUsers.blockedUserList.contains(where: { $0.userInfo.id == userInfo.id }) {
                        blockedUsers.blockedUserList.append(blockedUser)
```

- 이때 비교를 위해 Equtable 프로토콜을 채택하게 되었습니다.

### 해결해야 할 문제
#### 1. Firebase Store 읽기 사용량에 관한 문제
`BlockedUsersListView`에 최초 진입할 때(.onViewDidLoad), 새로 고침할 때 마다
`convertUserInfo()`가 실행되어 Firebase Store의 읽기 사용량이 증가합니다.
이를 줄일 수 있는 방법을 찾아야 합니다.
#### 2. `convertUserInfo()`의 실행 시점에 관한 문제

| BlockedUsersListView >. BlockedUsersListCell |
|:-----------------------------------------------:|
| ![Simulator Screen Recording - iPhone 14 Pro - 2023-04-25 at 21 27 11](https://user-images.githubusercontent.com/64696968/234275946-679c6048-5dd6-472c-bdd4-cb081a25971e.gif) |

- `BlockedUsersListView`에 진입할 때 `convertUserInfo()`가 실행되기 때문에
진입하기 전에는 BlockedUsers 배열이 비어있어 Settings > Account의 BlockedUsers의 수가 0으로 보입니다.
- 최초 진입 후에는 정상 작동
- 뿐만 아니라, 유저를 차단하는 쪽에서도 유저 타입 변환과 관련한 문제가 있어
이 메서드를 앱 최초 실행시에 상위뷰에서 실행되도록 하여
차단하는 곳과 차단 해제하는 곳 모두에서 사용할 수 있도록 하면 좋지 않을까 하는 생각입니다.


### 📸 스크린샷
| Settings > Account | Blocked users |
|:-------:|:-------:|
| <img width="300" alt="image" src="https://user-images.githubusercontent.com/64696968/234277829-65ffcb91-df0b-4d8b-a389-567ec5395c3d.png"> | <img width="300" alt="image" src="https://user-images.githubusercontent.com/64696968/234278035-0154a387-1a41-4c42-be1b-e87a2961cc39.png"> |
