### PR TITLE
[Feat] 차단 여부에 대한 채팅 기능 분기처리를 구현했습니다.

### DIFF
--- a/GitSpace.xcodeproj/project.pbxproj
+++ b/GitSpace.xcodeproj/project.pbxproj
@@ -115,6 +115,7 @@
 		6E128D6729A498A50004AEC8 /* Image+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E128D6629A498A50004AEC8 /* Image+.swift */; };
 		6E38C6042991EF380043A8BB /* ChatListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E38C6032991EF380043A8BB /* ChatListCell.swift */; };
 		6E38C6062991EF590043A8BB /* ChatListSkeletonCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E38C6052991EF590043A8BB /* ChatListSkeletonCell.swift */; };
+		6E54675F29F7F8E300F2C3C2 /* GSTextEditorLayoutModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E54675E29F7F8E300F2C3C2 /* GSTextEditorLayoutModifier.swift */; };
 		6E70333C29890AD000FFC018 /* ChatUserRecommendationSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E70333B29890AD000FFC018 /* ChatUserRecommendationSection.swift */; };
 		6E70333E29890ADE00FFC018 /* ChatListSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E70333D29890ADE00FFC018 /* ChatListSection.swift */; };
 		6E8C05C7297781BB002C9F45 /* ChatRoomInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8C05C6297781BB002C9F45 /* ChatRoomInfoView.swift */; };
@@ -285,6 +286,7 @@
 		6E128D6629A498A50004AEC8 /* Image+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image+.swift"; sourceTree = "<group>"; };
 		6E38C6032991EF380043A8BB /* ChatListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatListCell.swift; sourceTree = "<group>"; };
 		6E38C6052991EF590043A8BB /* ChatListSkeletonCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatListSkeletonCell.swift; sourceTree = "<group>"; };
+		6E54675E29F7F8E300F2C3C2 /* GSTextEditorLayoutModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSTextEditorLayoutModifier.swift; sourceTree = "<group>"; };
 		6E70333B29890AD000FFC018 /* ChatUserRecommendationSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatUserRecommendationSection.swift; sourceTree = "<group>"; };
 		6E70333D29890ADE00FFC018 /* ChatListSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatListSection.swift; sourceTree = "<group>"; };
 		6E8C05C6297781BB002C9F45 /* ChatRoomInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRoomInfoView.swift; sourceTree = "<group>"; };
@@ -621,6 +623,7 @@
 				22C5412A298CCAD200CC89EC /* TabBarBackgroundModifier.swift */,
 				7019EDBC2997EC7700135F26 /* PinnedViewHeaderModifier.swift */,
 				689A88B629ACED97006F177A /* ViewDidLoadModifier.swift */,
+				6E54675E29F7F8E300F2C3C2 /* GSTextEditorLayoutModifier.swift */,
 			);
 			path = Modifiers;
 			sourceTree = "<group>";
@@ -955,6 +958,7 @@
 				22E9ECF3299BB92100D5A9C6 /* Owner.swift in Sources */,
 				7019EDBD2997EC7700135F26 /* PinnedViewHeaderModifier.swift in Sources */,
 				22C54129298CC36D00CC89EC /* GSTabBarBackGround.swift in Sources */,
+				6E54675F29F7F8E300F2C3C2 /* GSTextEditorLayoutModifier.swift in Sources */,
 				EEEF740C298D784C00FABEA3 /* GSCanvas.swift in Sources */,
 				3427736B2994BA1F00818816 /* SetWorkingHoursView.swift in Sources */,
 				2201724029B9E122006C34D3 /* CurrentUserProfileViewModel.swift in Sources */,

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -201,9 +201,7 @@ struct ChatRoomView: View {
                     .frame(width: 28, height: 23)
             }
              */
-            
             contentTextEditor
-                
         }
         .padding(.bottom, 15)
         .padding(.vertical, -3)
@@ -213,17 +211,21 @@ struct ChatRoomView: View {
     
     // MARK: GSTextEditor - 메세지 입력 필드와 전송 버튼
     private var contentTextEditor: some View {
-        GSTextEditor.CustomTextEditorView(style: .message,
-                                          text: $contentField,
-                                          sendableImage: "paperplane.fill",
-                                          unSendableImage: "paperplane") {
+        GSTextEditor.CustomTextEditorView(
+            style: .message,
+            text: $contentField,
+            isBlocked: true,
+            sendableImage: "paperplane.fill",
+            unSendableImage: "paperplane"
+        ) {
             Task {
                 await addContent()
             }
         }
-                                          .textInputAutocapitalization(.never)
-                                          .disableAutocorrection(true)
+        .textInputAutocapitalization(.never)
+        .disableAutocorrection(true)
     }
+
     
     // MARK: -Methods
     // MARK: Method - 유저가 읽지 않은 메세지 갯수를 0으로 초기화하고 DB에 업데이트하는 함수

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -214,6 +214,7 @@ struct ChatRoomView: View {
         GSTextEditor.CustomTextEditorView(
             style: .message,
             text: $contentField,
+            // TODO: isBlocked 아규먼트에 한호님의 verifyBlock 로직으로 차단 여부 검사하는 로직 연결
             isBlocked: true,
             sendableImage: "paperplane.fill",
             unSendableImage: "paperplane"

--- a/GitSpace/Sources/Views/Knock/SendKnockView.swift
+++ b/GitSpace/Sources/Views/Knock/SendKnockView.swift
@@ -283,6 +283,7 @@ Please write a message carefully.
                             if !isKnockSent {
                                 GSTextEditor.CustomTextEditorView(style: .message,
                                                                   text: $knockMessage,
+                                                                  isBlocked: false,
                                                                   sendableImage: "paperplane.fill",
                                                                   unSendableImage: "paperplane") {
                                     Task {
@@ -378,6 +379,7 @@ Please write a message carefully.
                             if !isKnockSent {
                                 GSTextEditor.CustomTextEditorView(style: .message,
                                                                   text: $knockMessage,
+                                                                  isBlocked: false,
                                                                   sendableImage: "paperplane.fill",
                                                                   unSendableImage: "paperplane") {
                                     Task {

--- a/GitSpace/Utilities/Components/GSTextEditor.swift
+++ b/GitSpace/Utilities/Components/GSTextEditor.swift
@@ -108,7 +108,9 @@ struct GSTextEditor {
             let floatNewLineCounter = CGFloat(newLineCounter)
             
             // 텍스트 길이에 의한 자동 줄바꿈 갯수
-            let floatAutoLineBreakCount = CGFloat(autoLineBreakCount(textEditorWidth: textEditorWidth))
+            let floatAutoLineBreakCount = CGFloat(
+                autoLineBreakCount(textEditorWidth: textEditorWidth)
+            )
             
             // 총 라인 갯수
             let floatTotalLineCount = floatNewLineCounter + floatAutoLineBreakCount
@@ -127,7 +129,9 @@ struct GSTextEditor {
             + const.TEXTEDITOR_FRAME_HEIGHT_FREESPACE
 
             // 계산한 Editor 높이가 최대 Editor 높이보다 크면 최대 Editor 높이로 고정
-            textEditorHeight = tempTextEditorHeight > maxHeight ? maxHeight : tempTextEditorHeight
+            textEditorHeight = tempTextEditorHeight > maxHeight
+            ? maxHeight
+            : tempTextEditorHeight
         }
         
         // MARK: Method - 개행 문자 기준으로 텍스트를 분리하고, 각 텍스트 길이가 Editor 길이를 초과하는지 계산하여 필요한 줄바꿈 수를 반환하는 메서드
@@ -238,6 +242,11 @@ struct GSTextEditor {
                             .foregroundColor(isMessageSendable
                                              ? .primary
                                              : .gsGray2)
+                            .foregroundColor(
+                                isMessageSendable
+                                ? .primary
+                                : .gsGray2
+                            )
                         }
                         .disabled(!isMessageSendable)
                     }

--- a/GitSpace/Utilities/Components/GSTextEditor.swift
+++ b/GitSpace/Utilities/Components/GSTextEditor.swift
@@ -172,50 +172,75 @@ struct GSTextEditor {
         var body: some View {
             switch style {
             case .message:
-                HStack {
-                    GeometryReader { proxy in
-                        TextEditor(text: text)
-                            .font(font)
-                            .lineSpacing(lineSpace)
-                            .frame(maxHeight: textEditorHeight)
-                            .padding(.horizontal, const.TEXTEDITOR_INSET_HORIZONTAL)
-                            .padding(.bottom, -3)
-                            .overlay {
-                                RoundedRectangle(cornerRadius: const.TEXTEDITOR_STROKE_CORNER_RADIUS)
-                                    .stroke()
-                                    .foregroundColor(.gsGray2)
-                            }
-                            .onAppear {
-                                setTextEditorStartHeight()
-                            }
-                            .onChange(of: text.wrappedValue) { n in
-                                // FIXME: 현재 버퍼값으로는 텍스트 길이와 에디터 길이 사이의 공식을 정확하게 구하지 못해서 당장 작동은 하지만 정확한 값을 구해서 수정 필요 By. 태영
-                                let textEditorWidth = proxy.size.width - (const.TEXTEDITOR_INSET_HORIZONTAL * 2 + 10)
-                                let autoLineBreakCounter = autoLineBreakCount(textEditorWidth: textEditorWidth)
-                                let multiTextEditorWidth = textEditorWidth - CGFloat(autoLineBreakCounter * 2)
-                                
-                                updateTextEditorCurrentHeight(textEditorWidth: multiTextEditorWidth)
-                            }
-                            .onChange(of: textWidth) { newValue in
-                                stateTextWidth = newValue
-                            }
-                    }
-                    .frame(maxHeight: textEditorHeight)
-                    
-                    Button {
-                        action()
-                    } label: {
-                        Image(systemName: isMessageSendable
-                              ? sendableImage
-                              : unSendableImage)
+                
+                if isBlocked {
+                    TextEditor(text: .constant("Cannot chat with blocked user"))
+                        .font(font)
+                        .foregroundColor(.gsGray1)
+                        .lineSpacing(lineSpace)
+                        .frame(maxHeight: textEditorHeight)
+                        .padding(.horizontal, const.TEXTEDITOR_INSET_HORIZONTAL)
+                        .padding(.bottom, -3)
+                        .disabled(true)
+                        .overlay {
+                            RoundedRectangle(cornerRadius: const.TEXTEDITOR_STROKE_CORNER_RADIUS)
+                                .stroke()
+                                .foregroundColor(.gsGray2)
+                                .background(Color.gsGray3.opacity(0.7))
+                                .cornerRadius(const.TEXTEDITOR_STROKE_CORNER_RADIUS)
+                        }
+                        .onAppear {
+                            setTextEditorStartHeight()
+                        }
+
+                } else {
+                    HStack {
+                        GeometryReader { proxy in
+                            TextEditor(text: text)
+                                .font(font)
+                                .lineSpacing(lineSpace)
+                                .frame(maxHeight: textEditorHeight)
+                                .padding(.horizontal, const.TEXTEDITOR_INSET_HORIZONTAL)
+                                .padding(.bottom, -3)
+                                .overlay {
+                                    RoundedRectangle(cornerRadius: const.TEXTEDITOR_STROKE_CORNER_RADIUS)
+                                        .stroke()
+                                        .foregroundColor(.gsGray2)
+                                }
+                                .onAppear {
+                                    setTextEditorStartHeight()
+                                }
+                                .onChange(of: text.wrappedValue) { n in
+                                    // FIXME: 현재 버퍼값으로는 텍스트 길이와 에디터 길이 사이의 공식을 정확하게 구하지 못해서 당장 작동은 하지만 정확한 값을 구해서 수정 필요 By. 태영
+                                    let textEditorWidth = proxy.size.width - (const.TEXTEDITOR_INSET_HORIZONTAL * 2 + 10)
+                                    let autoLineBreakCounter = autoLineBreakCount(textEditorWidth: textEditorWidth)
+                                    let multiTextEditorWidth = textEditorWidth - CGFloat(autoLineBreakCounter * 2)
+                                    
+                                    updateTextEditorCurrentHeight(textEditorWidth: multiTextEditorWidth)
+                                }
+                                .onChange(of: textWidth) { newValue in
+                                    stateTextWidth = newValue
+                                }
+                        }
+                        .frame(maxHeight: textEditorHeight)
+                        
+                        Button {
+                            action()
+                        } label: {
+                            Image(
+                                systemName: isMessageSendable
+                                ? sendableImage
+                                : unSendableImage
+                            )
                             .resizable()
                             .aspectRatio(contentMode: .fit)
                             .frame(width: 22, height: 22)
                             .foregroundColor(isMessageSendable
                                              ? .primary
                                              : .gsGray2)
+                        }
+                        .disabled(!isMessageSendable)
                     }
-                    .disabled(!isMessageSendable)
                 }
             }
         }

--- a/GitSpace/Utilities/Components/GSTextEditor.swift
+++ b/GitSpace/Utilities/Components/GSTextEditor.swift
@@ -32,6 +32,7 @@ struct GSTextEditor {
         let text: Binding<String>
         let font: Font
         let lineSpace: CGFloat
+        let isBlocked: Bool
         
         // MARK: SendButton 관련 프로퍼티
         let sendableImage: String
@@ -151,6 +152,7 @@ struct GSTextEditor {
             text: Binding<String>,
             font: Font = .body,
             lineSpace: CGFloat = 2,
+            isBlocked: Bool,
             sendableImage: String,
             unSendableImage: String,
             action: @escaping () -> Void
@@ -159,6 +161,7 @@ struct GSTextEditor {
             self.text = text
             self.font = font
             self.lineSpace = lineSpace
+            self.isBlocked = isBlocked
             self.sendableImage = sendableImage
             self.unSendableImage = unSendableImage
             self.action = action

--- a/GitSpace/Utilities/Components/GSTextEditor.swift
+++ b/GitSpace/Utilities/Components/GSTextEditor.swift
@@ -228,7 +228,7 @@ struct GSTextEditor {
                                     setTextEditorStartHeight()
                                 }
                                 .onChange(of: text.wrappedValue) { n in
-                                    // FIXME: 현재 버퍼값으로는 텍스트 길이와 에디터 길이 사이의 공식을 정확하게 구하지 못해서 당장 작동은 하지만 정확한 값을 구해서 수정 필요 By. 태영
+                                    // FIXME: 현재 버퍼값으로는 텍스트 길이와 에디터 길이 사이의 공식을 정확하게 구하지 못함 -> 당장 작동은 하지만 정확한 값을 구해서 수정 필요 By. 태영
                                     let textEditorWidth = proxy.size.width - (const.TEXTEDITOR_INSET_HORIZONTAL * 2 + 10)
                                     let autoLineBreakCounter = autoLineBreakCount(textEditorWidth: textEditorWidth)
                                     let multiTextEditorWidth = textEditorWidth - CGFloat(autoLineBreakCounter * 2)

--- a/GitSpace/Utilities/Components/GSTextEditor.swift
+++ b/GitSpace/Utilities/Components/GSTextEditor.swift
@@ -178,34 +178,47 @@ struct GSTextEditor {
             case .message:
                 
                 if isBlocked {
-                    TextEditor(text: .constant(const.TEXTEDITOR_BLOCKED_LABEL))
-                        .font(font)
-                        .foregroundColor(.gsGray1)
-                        .lineSpacing(lineSpace)
-                        .frame(maxHeight: textEditorHeight)
-                        .padding(.horizontal, const.TEXTEDITOR_INSET_HORIZONTAL)
-                        .padding(.bottom, -3)
-                        .disabled(true)
-                        .overlay {
-                            RoundedRectangle(cornerRadius: const.TEXTEDITOR_STROKE_CORNER_RADIUS)
-                                .stroke()
-                                .foregroundColor(.gsGray2)
-                                .background(Color.gsGray3.opacity(0.7))
-                                .cornerRadius(const.TEXTEDITOR_STROKE_CORNER_RADIUS)
-                        }
-                        .onAppear {
-                            setTextEditorStartHeight()
-                        }
-
+                    TextEditor(
+                        text: .constant(const.TEXTEDITOR_BLOCKED_LABEL)
+                    )
+                    .modifier(
+                        GSTextEditorLayoutModifier(
+                            font: font,
+                            color: .gsGray1,
+                            lineSpace: lineSpace,
+                            maxHeight: textEditorHeight,
+                            horizontalInset: const.TEXTEDITOR_INSET_HORIZONTAL,
+                            bottomInset: const.TEXTEDITOR_INSET_BOTTOM
+                        )
+                    )
+                    .disabled(true)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: const.TEXTEDITOR_STROKE_CORNER_RADIUS)
+                            .stroke()
+                            .foregroundColor(.gsGray2)
+                            .background(
+                                Color.gsGray3.opacity(0.7)
+                            )
+                            .cornerRadius(const.TEXTEDITOR_STROKE_CORNER_RADIUS)
+                    }
+                    .onAppear {
+                        setTextEditorStartHeight()
+                    }
+                    
                 } else {
                     HStack {
                         GeometryReader { proxy in
                             TextEditor(text: text)
-                                .font(font)
-                                .lineSpacing(lineSpace)
-                                .frame(maxHeight: textEditorHeight)
-                                .padding(.horizontal, const.TEXTEDITOR_INSET_HORIZONTAL)
-                                .padding(.bottom, -3)
+                                .modifier(
+                                    GSTextEditorLayoutModifier(
+                                        font: font,
+                                        color: .primary,
+                                        lineSpace: lineSpace,
+                                        maxHeight: textEditorHeight,
+                                        horizontalInset: const.TEXTEDITOR_INSET_HORIZONTAL,
+                                        bottomInset: const.TEXTEDITOR_INSET_BOTTOM
+                                    )
+                                )
                                 .overlay {
                                     RoundedRectangle(cornerRadius: const.TEXTEDITOR_STROKE_CORNER_RADIUS)
                                         .stroke()

--- a/GitSpace/Utilities/Components/GSTextEditor.swift
+++ b/GitSpace/Utilities/Components/GSTextEditor.swift
@@ -251,10 +251,10 @@ struct GSTextEditor {
                             )
                             .resizable()
                             .aspectRatio(contentMode: .fit)
-                            .frame(width: 22, height: 22)
-                            .foregroundColor(isMessageSendable
-                                             ? .primary
-                                             : .gsGray2)
+                            .frame(
+                                width: const.TEXTEDITOR_SEND_BUTTON_SIZE,
+                                height: const.TEXTEDITOR_SEND_BUTTON_SIZE
+                            )
                             .foregroundColor(
                                 isMessageSendable
                                 ? .primary

--- a/GitSpace/Utilities/Components/GSTextEditor.swift
+++ b/GitSpace/Utilities/Components/GSTextEditor.swift
@@ -174,7 +174,7 @@ struct GSTextEditor {
             case .message:
                 
                 if isBlocked {
-                    TextEditor(text: .constant("Cannot chat with blocked user"))
+                    TextEditor(text: .constant(const.TEXTEDITOR_BLOCKED_LABEL))
                         .font(font)
                         .foregroundColor(.gsGray1)
                         .lineSpacing(lineSpace)

--- a/GitSpace/Utilities/Constant.swift
+++ b/GitSpace/Utilities/Constant.swift
@@ -137,6 +137,7 @@ public enum Constant {
         static let TEXTEDITOR_INSET_HORIZONTAL: CGFloat = 10
         static let TEXTEDITOR_STROKE_CORNER_RADIUS: CGFloat = 20
         static let TEXTEDITOR_FRAME_HEIGHT_FREESPACE: CGFloat = 20
+        static let TEXTEDITOR_BLOCKED_LABEL: String = "Cannot chat with blocked user"
     }
 
 	public enum LabelHierarchy {

--- a/GitSpace/Utilities/Constant.swift
+++ b/GitSpace/Utilities/Constant.swift
@@ -135,9 +135,12 @@ public enum Constant {
         static let TEXTEDITOR_DEFAULT_LINE_COUNT: Int = 1
         static let TEXTEDITOR_MAX_LINE_COUNT: Int = 5
         static let TEXTEDITOR_INSET_HORIZONTAL: CGFloat = 10
+        static let TEXTEDITOR_INSET_BOTTOM: CGFloat = -3
         static let TEXTEDITOR_STROKE_CORNER_RADIUS: CGFloat = 20
         static let TEXTEDITOR_FRAME_HEIGHT_FREESPACE: CGFloat = 20
         static let TEXTEDITOR_BLOCKED_LABEL: String = "Cannot chat with blocked user"
+        
+        static let TEXTEDITOR_SEND_BUTTON_SIZE: CGFloat = 22
     }
 
 	public enum LabelHierarchy {

--- a/GitSpace/Utilities/Modifiers/GSTextEditorLayoutModifier.swift
+++ b/GitSpace/Utilities/Modifiers/GSTextEditorLayoutModifier.swift
@@ -1,0 +1,28 @@
+//
+//  GSTextEditorLayoutModifier.swift
+//  GitSpace
+//
+//  Created by 원태영 on 2023/04/25.
+//
+
+import SwiftUI
+
+struct GSTextEditorLayoutModifier: ViewModifier {
+    
+    let font: Font
+    let color: Color
+    let lineSpace: CGFloat
+    let maxHeight: CGFloat
+    let horizontalInset: CGFloat
+    let bottomInset: CGFloat
+    
+    func body(content: Content) -> some View {
+        content
+            .font(font)
+            .foregroundColor(color)
+            .lineSpacing(lineSpace)
+            .frame(maxHeight: maxHeight)
+            .padding(.horizontal, horizontalInset)
+            .padding(.bottom, bottomInset)
+    }
+}


### PR DESCRIPTION
## 개요 및 관련 이슈
- 유저의 차단 여부를 검사하여 차단한 / 차단당한 유저에게 채팅 메세지를 전송하지 못하도록 처리했습니다.
- #372 

## 작업 사항
- GSTextEditor에 isBlocked 프로퍼티 추가
- isBlocked 조건에 따라 TextEditor 속성 분기 처리
- GSTextEditor 분기에서 공통되는 속성자에 대한 Modifier 구현

## 차단 조건 분기
```swift
if isBlocked {
    TextEditor(
        text: .constant(const.TEXTEDITOR_BLOCKED_LABEL)
    )
    .modifier(
        GSTextEditorLayoutModifier(
            font: font,
            color: .gsGray1,
            lineSpace: lineSpace,
            maxHeight: textEditorHeight,
            horizontalInset: const.TEXTEDITOR_INSET_HORIZONTAL,
            bottomInset: const.TEXTEDITOR_INSET_BOTTOM
        )
    )
    .disabled(true)
    .overlay {
        RoundedRectangle(cornerRadius: const.TEXTEDITOR_STROKE_CORNER_RADIUS)
            .stroke()
            .foregroundColor(.gsGray2)
            .background(
                Color.gsGray3.opacity(0.7)
            )
            .cornerRadius(const.TEXTEDITOR_STROKE_CORNER_RADIUS)
    }
    .onAppear {
        setTextEditorStartHeight()
    }
    
} else {

  ...

}
```

### 차단이 적용된 채팅방 화면
<img style="margin:10px 0 0px 0" width="300" src="https://user-images.githubusercontent.com/45925685/234285284-466dd015-d267-4cb3-8bd3-c6cb72871b33.png" alt="BlockedTextEditor"/>
