### PR TITLE
[Fix] 차단/차단제안 뷰의 텍스트 버튼을 다시 디자인했습니다.

### DIFF
--- a/GitSpace/Sources/Views/Common/BlockView.swift
+++ b/GitSpace/Sources/Views/Common/BlockView.swift
@@ -49,7 +49,12 @@ struct BlockView: View {
                         isBlockViewShowing.toggle()
                     } label: {
                         Text("Yes")
+                            .foregroundColor(.white)
+                            .frame(width: 100, height: 50)
+                            .background(Color.gsRed)
+                            .cornerRadius(15)
                     }
+                    
                 }
             }
         }

--- a/GitSpace/Sources/Views/Common/BlockView.swift
+++ b/GitSpace/Sources/Views/Common/BlockView.swift
@@ -42,6 +42,11 @@ struct BlockView: View {
                         isBlockViewShowing.toggle()
                     } label: {
                         Text("No")
+                            .frame(width: 100, height: 50)
+                            .overlay {
+                                RoundedRectangle(cornerRadius: 15)
+                                    .stroke()
+                            }
                     }
                     
                     GSButton.CustomButtonView(style: .plainText(isDestructive: true)) {

--- a/GitSpace/Sources/Views/Common/SuggestBlockView.swift
+++ b/GitSpace/Sources/Views/Common/SuggestBlockView.swift
@@ -37,6 +37,10 @@ struct SuggestBlockView: View {
                     isBlockViewShowing.toggle()
                 } label: {
                     Text("Yes")
+                        .foregroundColor(.white)
+                        .frame(width: 100, height: 50)
+                        .background(Color.gsRed)
+                        .cornerRadius(15)
                 }
             }
 

--- a/GitSpace/Sources/Views/Common/SuggestBlockView.swift
+++ b/GitSpace/Sources/Views/Common/SuggestBlockView.swift
@@ -30,6 +30,11 @@ struct SuggestBlockView: View {
                     isSuggestBlockViewShowing.toggle()
                 } label: {
                     Text("No")
+                        .frame(width: 100, height: 50)
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 15)
+                                .stroke()
+                        }
                 }
                 
                 GSButton.CustomButtonView(style: .plainText(isDestructive: true)) {


### PR DESCRIPTION
## 개요 및 관련 이슈
- 차단/차단제안 뷰의 텍스트 버튼을 새롭게 디자인하여 적용하였습니다.
- #383 

## 작업 사항
- 차단/차단제안 뷰의 텍스트 버튼을 한번 바꾼 후 팀원들의 피드백을 받아 다시 텍스트 버튼을 Re-design 했습니다.
- 'Yes' 버튼은 빨간색 바탕에 흰색 텍스트로 변경
- 'No' 버튼은 흰색 테두리를 가진 텍스트 버튼으로 변경

## 📸 스크린샷
|              | BlockView | SuggestBlockView |
|:-------:|:----:|:----:|
| After    |  <img width="300" alt="image" src="https://user-images.githubusercontent.com/50159740/234788908-44fc4be0-341c-4f55-bf9f-d12f46df3469.png">  |  <img width="300" alt="image" src="https://user-images.githubusercontent.com/50159740/234789369-a035b2d5-1a19-4c21-b390-b90f20cc2390.png"> |
| Before | <img width="300" alt="image" src="https://user-images.githubusercontent.com/50159740/234221035-6c9d0e02-17db-4178-a442-7b28c4bee90c.png"> | <img width="300" alt="image" src="https://user-images.githubusercontent.com/50159740/234220921-d3ad3ca7-4661-4d77-a996-6799599411cb.png"> |
