### PR TITLE
[Feat] TargetUserProfileView에서 차단 기능을 구현하고, 차단여부에 따라 뷰에 반영하였습니다.

### DIFF
--- a/GitSpace/Sources/Views/Common/BlockView.swift
+++ b/GitSpace/Sources/Views/Common/BlockView.swift
@@ -7,8 +7,13 @@
 
 import SwiftUI
 
-struct BlockView: View {
+struct BlockView: View, Blockable {
+    
+    @EnvironmentObject var userInfoManager: UserStore
+    @EnvironmentObject var blockedUsers: BlockedUsers
     @Binding var isBlockViewShowing: Bool
+    
+    let targetUser: UserInfo
     
     var body: some View {
         VStack {
@@ -47,6 +52,14 @@ struct BlockView: View {
                     GSButton.CustomButtonView(style: .plainText(isDestructive: true)) {
                         /* Block Method Call */
                         isBlockViewShowing.toggle()
+                        Task {
+                            if let currentUser = userInfoManager.currentUser {
+                                try await blockTargetUser(in: currentUser, with: targetUser)
+                            }
+                        }
+                        let targetGitHubUser =
+                        GithubUser(id: targetUser.githubID, login: targetUser.githubLogin, name: targetUser.githubName, email: targetUser.githubEmail, avatar_url: targetUser.avatar_url, bio: targetUser.bio, company: targetUser.company, location: targetUser.location, blog: targetUser.blog, public_repos: targetUser.public_repos, followers: targetUser.followers, following: targetUser.following)
+                        blockedUsers.blockedUserList.append((targetUser, targetGitHubUser))
                     } label: {
                         Text("Yes")
                     }
@@ -58,6 +71,7 @@ struct BlockView: View {
 
 struct BlockView_Previews: PreviewProvider {
     static var previews: some View {
-        BlockView(isBlockViewShowing: .constant(true))
+        BlockView(isBlockViewShowing: .constant(true), targetUser: UserInfo(id: "", createdDate: Date.now, deviceToken: "", blockedUserIDs: ["1"], githubID: 0, githubLogin: "", githubName: "test", githubEmail: "test", avatar_url: "test", bio: nil, company: nil, location: nil, blog: nil, public_repos: 0, followers: 0, following: 0))
+            .environmentObject(BlockedUsers())
     }
 }


### PR DESCRIPTION
## 개요 및 관련 이슈
- TargetUserProfileView에서 유저 차단 기능을 구현하였고, 차단여부에 따라 뷰에 반영할 수 있도록 작업하였습니다.
- #376 

## 작업 사항
- TargetUserProfileView에 진입시, 현재 GitHub에서 해당 유저 팔로우 여부가 초기화되어 나타나는 현상 수정
    - TargetUserProfileViewModel을 ObservedObject에서 StateObject로 변경 
- TargetUserProfileView에 진입시 해당 유저가 Blocked된 유저인지 여부를 판별합니다
    - 해당 여부에 따라 뷰 상단에 Blocked 유저인지 표시합니다. 
- BlockView에서는 지난 회의에서 함께 만들어 두었던 `Blockable` 프로토콜을 채택하여, 유저를 block하는 메서드를 사용하였습니다.
- @guguhanogu 님이 block유저를 관리하기 위해 만들어둔 EnvironmentObject를 사용하였습니다.

## 트러블슈팅 및 논의사항
![스크린샷 2023-04-28 오전 1 01 08](https://user-images.githubusercontent.com/19788294/234919936-aeae9d7d-22f4-40be-921f-81077d50dbab.png)

- UIViewControllerRepresentable로 구현되어 있는 HalfSheetManager를 통해 BlockView를 열어줄 때 에러 발생
    - EnvironmentObject 를 가지고 있는 BlockView에서 @guguhanogu 님이 만들어둔 EnvironmentObject가 없다는 내용의 에러 발생 
    - 상위뷰인 TargetUserProfileView에서 BlockView가 생성될 때 EnvironmentObject에 추가되도록 .environmentObject를 추가하여 해결
    - 기능은 동작하나, 원인 파악중입니다.

## 📸 스크린샷
|              | 일반 유저 | 차단 유저|
|:-------:|:----:|:----:|
| TargetUserProfileView  | <img width="300" src="https://user-images.githubusercontent.com/19788294/234915901-78511f3d-028e-47af-829c-825a5e31f854.png" > | <img width="300" src="https://user-images.githubusercontent.com/19788294/234916523-35140ac9-b93e-4aee-9f9a-e28d579bfd0d.png"> |


