### PR TITLE
[Feat] 채팅방에 차단 검사와 신고 Sheet를 연결했습니다.

### DIFF
--- a/GitSpace/Sources/ViewModels/MessageViewModel.swift
+++ b/GitSpace/Sources/ViewModels/MessageViewModel.swift
@@ -19,6 +19,7 @@ final class MessageStore: ObservableObject {
     @Published var isMessageAdded: Bool = false
     @Published var deletedMessage: Message? // 메세지 셀 삭제 시 onChange로 반응하는 대상 메세지
     @Published var reportedMessage: Message? // 메세지 셀 신고 시 onChange로 반응하는 대상 메세지
+    @Published var isReported: Bool = false // 신고 sheet를 토글하기 위해 ChatRoomView의 onChange에서 감지하는 상태값
     @Published var isFetchMessagesDone: Bool = false
     
     var remainMessages: [Message] = []

--- a/GitSpace/Sources/ViewModels/MessageViewModel.swift
+++ b/GitSpace/Sources/ViewModels/MessageViewModel.swift
@@ -18,8 +18,8 @@ final class MessageStore: ObservableObject {
     @Published var messages: [Message] = []
     @Published var isMessageAdded: Bool = false
     @Published var deletedMessage: Message? // 메세지 셀 삭제 시 onChange로 반응하는 대상 메세지
-    @Published var reportedMessage: Message? // 메세지 셀 신고 시 onChange로 반응하는 대상 메세지
     @Published var isReported: Bool = false // 신고 sheet를 토글하기 위해 ChatRoomView의 onChange에서 감지하는 상태값
+    @Published var reportedMessage: Message? // 메세지 셀 신고 대상이 되는 메세지 객체
     @Published var isFetchMessagesDone: Bool = false
     
     var remainMessages: [Message] = []

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -30,6 +30,9 @@ struct ChatRoomView: View, Blockable {
     @State private var contentField: String = ""
     @State private var unreadMessageIndex: Int?
     @State private var preMessageIDs: [String] = []
+    @State private var showingReportView: Bool = false
+    @State private var showingSuggestBlockView: Bool = false
+    @State private var showingBlockView: Bool = false
     
     
     var body: some View {

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -147,10 +147,8 @@ struct ChatRoomView: View, Blockable {
             }
         }
         // 상대방 MessageCell ContextMenu에서 신고 버튼을 탭하면 수행되는 로직
-        .onChange(of: messageStore.reportedMessage?.id) { id in
-            
-            // TODO: 다혜님의 PR에 포함된 신고 sheet present 로직 구현
-            
+        .onChange(of: messageStore.isReported) { state in
+            showingReportView = true
         }
         // 유저가 앱 화면에서 벗어났을 때 수행되는 로직
         .onChange(of: scenePhase) { currentPhase in

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -23,11 +23,10 @@ struct ChatRoomView: View, Blockable {
     let targetUserInfo: UserInfo
     
     @Environment(\.scenePhase) var scenePhase
-    @EnvironmentObject var chatStore: ChatStore
-    @EnvironmentObject var messageStore: MessageStore
-    @EnvironmentObject var userStore: UserStore
-    @EnvironmentObject var pushNotificationManager: PushNotificationManager
-    @StateObject private var keyboardHandler = KeyboardHandler()
+    @EnvironmentObject private var chatStore: ChatStore
+    @EnvironmentObject private var messageStore: MessageStore
+    @EnvironmentObject private var userStore: UserStore
+    @EnvironmentObject private var pushNotificationManager: PushNotificationManager
     @State private var contentField: String = ""
     @State private var unreadMessageIndex: Int?
     @State private var preMessageIDs: [String] = []

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -222,8 +222,10 @@ struct ChatRoomView: View, Blockable {
         GSTextEditor.CustomTextEditorView(
             style: .message,
             text: $contentField,
-            // TODO: isBlocked 아규먼트에 한호님의 verifyBlock 로직으로 차단 여부 검사하는 로직 연결
-            isBlocked: true,
+            isBlocked: isBlockedEither(
+                by: userStore.currentUser ?? .getFaliedUserInfo(),
+                by: targetUserInfo
+            ),
             sendableImage: "paperplane.fill",
             unSendableImage: "paperplane"
         ) {

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 
 // MARK: -View : 채팅방 뷰
-struct ChatRoomView: View {
+struct ChatRoomView: View, Blockable {
     
     enum MakeChatCase {
         case addContent

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -37,8 +37,9 @@ struct ChatRoomView: View, Blockable {
     
     var body: some View {
         VStack {
-            // 채팅 메세지 스크롤 뷰
+            
             ScrollViewReader { proxy in
+                
                 ScrollView {
                     
                     TopperProfileView(targetUserInfo: targetUserInfo)

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -112,6 +112,18 @@ struct ChatRoomView: View, Blockable {
             }
              */
         }
+        .halfSheet(isPresented: $showingReportView) {
+            ReportView(
+                isReportViewShowing: $showingReportView,
+                isSuggestBlockViewShowing: $showingSuggestBlockView
+            )
+        }
+        .halfSheet(isPresented: $showingSuggestBlockView) {
+            SuggestBlockView(
+                isBlockViewShowing: $showingBlockView,
+                isSuggestBlockViewShowing: $showingSuggestBlockView
+            )
+        }
         .onDisappear {
             // 초기화 필요.
             pushNotificationManager.currentChatRoomID = nil

--- a/GitSpace/Sources/Views/Chat/ChatRoom/MessageCell.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/MessageCell.swift
@@ -79,6 +79,7 @@ struct MessageCell : View {
                             .contextMenu {
                                 Button {
                                     messageStore.reportedMessage = message
+                                    messageStore.isReported.toggle()
                                 } label: {
                                     Text("Report")
                                     Image(systemName: "exclamationmark.bubble")


### PR DESCRIPTION
## 개요 및 관련 이슈
- 채팅방에 차단 분기 처리를 위한 검사 로직 연결
- 신고 Sheet 추가
- #388 

## 작업 사항
- GSTextEditor에 차단 검사 메서드 호출 결과 전달
- 신고 sheet present 바인딩 변수 추가
- onChange에서 감지하기 위한 isReported 변수 추가
- 신고 sheet present 로직 추가
- 신고 sheet View 작성

## 논의 필요 사항
```swift
.halfSheet(isPresented: $showingReportView) {
    ReportView(
        isReportViewShowing: $showingReportView,
        isSuggestBlockViewShowing: $showingSuggestBlockView
    )
}

/* Submit Report */
GSButton.CustomButtonView(
    style: .secondary(isDisabled: isReportReasonSelected)
) {
    /* report method call */
    
    /* report view dismiss -> suggest block view appear*/
    dismiss()
    isReportViewShowing.toggle()
    isSuggestBlockViewShowing.toggle()
} label: {
    Text("Submit Report")
}
```
ReportView에 노크/채팅 메세지 객체를 전달하기 위해 report method call 로직 논의 필요 w. @dahae0320 

