### PR TITLE
[Fix] 유저를 블락할 경우, 블락했다는 사실을 알 수 있도록 뷰를 리프레시 합니다. 

### DIFF
--- a/GitSpace/Sources/Views/Common/BlockView.swift
+++ b/GitSpace/Sources/Views/Common/BlockView.swift
@@ -65,9 +65,10 @@ struct BlockView: View, Blockable {
                                 try await blockTargetUser(in: currentUser, with: targetUser)
                             }
                         }
-                        let targetGitHubUser =
-                        GithubUser(id: targetUser.githubID, login: targetUser.githubLogin, name: targetUser.githubName, email: targetUser.githubEmail, avatar_url: targetUser.avatar_url, bio: targetUser.bio, company: targetUser.company, location: targetUser.location, blog: targetUser.blog, public_repos: targetUser.public_repos, followers: targetUser.followers, following: targetUser.following)
+                        
+                        let targetGitHubUser = assignGitHubUser(to: targetUser)
                         blockedUsers.blockedUserList.append((targetUser, targetGitHubUser))
+                        
                     } label: {
                         Text("Yes")
                             .foregroundColor(.white)
@@ -80,6 +81,24 @@ struct BlockView: View, Blockable {
             }
         }
     }
+    
+    private func assignGitHubUser(to targetUser: UserInfo) -> GithubUser {
+        GithubUser(
+            id: targetUser.githubID,
+            login: targetUser.githubLogin,
+            name: targetUser.githubName,
+            email: targetUser.githubEmail,
+            avatar_url: targetUser.avatar_url,
+            bio: targetUser.bio,
+            company: targetUser.company,
+            location: targetUser.location,
+            blog: targetUser.blog,
+            public_repos: targetUser.public_repos,
+            followers: targetUser.followers,
+            following: targetUser.following
+        )
+    }
+    
 }
 
 struct BlockView_Previews: PreviewProvider {

--- a/GitSpace/Sources/Views/Common/BlockView.swift
+++ b/GitSpace/Sources/Views/Common/BlockView.swift
@@ -12,6 +12,7 @@ struct BlockView: View, Blockable {
     @EnvironmentObject var userInfoManager: UserStore
     @EnvironmentObject var blockedUsers: BlockedUsers
     @Binding var isBlockViewShowing: Bool
+    @Binding var isBlockedUser: Bool
     
     let targetUser: UserInfo
     
@@ -57,6 +58,8 @@ struct BlockView: View, Blockable {
                     GSButton.CustomButtonView(style: .plainText(isDestructive: true)) {
                         /* Block Method Call */
                         isBlockViewShowing.toggle()
+                        isBlockedUser.toggle()
+                        
                         Task {
                             if let currentUser = userInfoManager.currentUser {
                                 try await blockTargetUser(in: currentUser, with: targetUser)
@@ -81,7 +84,7 @@ struct BlockView: View, Blockable {
 
 struct BlockView_Previews: PreviewProvider {
     static var previews: some View {
-        BlockView(isBlockViewShowing: .constant(true), targetUser: UserInfo(id: "", createdDate: Date.now, deviceToken: "", blockedUserIDs: ["1"], githubID: 0, githubLogin: "", githubName: "test", githubEmail: "test", avatar_url: "test", bio: nil, company: nil, location: nil, blog: nil, public_repos: 0, followers: 0, following: 0))
+        BlockView(isBlockViewShowing: .constant(true), isBlockedUser: .constant(false), targetUser: UserInfo(id: "", createdDate: Date.now, deviceToken: "", blockedUserIDs: ["1"], githubID: 0, githubLogin: "", githubName: "test", githubEmail: "test", avatar_url: "test", bio: nil, company: nil, location: nil, blog: nil, public_repos: 0, followers: 0, following: 0))
             .environmentObject(BlockedUsers())
     }
 }

--- a/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
+++ b/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
@@ -342,7 +342,7 @@ struct TargetUserProfileView: View {
             }
             .halfSheet(isPresented: $isBlockViewShowing) {
                 if let targetUserInfo {
-                    BlockView(isBlockViewShowing: $isBlockViewShowing, targetUser: targetUserInfo)
+                    BlockView(isBlockViewShowing: $isBlockViewShowing, isBlockedUser: $isBlockedUser, targetUser: targetUserInfo)
                         .environmentObject(userInfoManager)
                         .environmentObject(blockedUsers)
                 }

--- a/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
+++ b/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
@@ -15,7 +15,7 @@ struct TargetUserProfileView: View {
     @EnvironmentObject var gitHubAuthManager: GitHubAuthManager
     @EnvironmentObject var userInfoManager: UserStore
     @EnvironmentObject var blockedUsers: BlockedUsers
-    @StateObject var viewModel = TargetUserProfileViewModel(gitHubService: GitHubService())
+    @StateObject var targetUserProfileViewModel = TargetUserProfileViewModel(gitHubService: GitHubService())
 
     @State private var markdownString = ""
     @State private var followButtonLable: String = "➕ Follow"
@@ -180,25 +180,25 @@ struct TargetUserProfileView: View {
                                 style: .secondary(isDisabled: false)
                             ) {
                                 Task {
-                                    if viewModel.isFollowingUser {
+                                    if targetUserProfileViewModel.isFollowingUser {
                                         // TODO: - 경고: 정말 unfollow 하시겠습니까?
                                         do {
-                                            try await viewModel.requestToUnfollowUser(who: user.login)
-                                            viewModel.isFollowingUser = false
+                                            try await targetUserProfileViewModel.requestToUnfollowUser(who: user.login)
+                                            targetUserProfileViewModel.isFollowingUser = false
                                         } catch(let error) {
                                             print(error)
                                         }
                                     } else {
                                         do {
-                                            try await viewModel.requestToFollowUser(who: user.login)
-                                            viewModel.isFollowingUser = true
+                                            try await targetUserProfileViewModel.requestToFollowUser(who: user.login)
+                                            targetUserProfileViewModel.isFollowingUser = true
                                         } catch(let error) {
                                             print(error)
                                         }
                                     }
                                 }
                             } label: {
-                                viewModel.isFollowingUser ?
+                                targetUserProfileViewModel.isFollowingUser ?
                                 GSText.CustomTextView(style: .buttonTitle1, string: "✅ Following")
                                     .frame(maxWidth: .infinity)
                                 :
@@ -222,25 +222,25 @@ struct TargetUserProfileView: View {
                             style: .secondary(isDisabled: false)
                         ) {
                             Task {
-                                if viewModel.isFollowingUser {
+                                if targetUserProfileViewModel.isFollowingUser {
                                     // TODO: - 경고: 정말 unfollow 하시겠습니까?
                                     do {
-                                        try await viewModel.requestToUnfollowUser(who: user.login)
-                                        viewModel.isFollowingUser = false
+                                        try await targetUserProfileViewModel.requestToUnfollowUser(who: user.login)
+                                        targetUserProfileViewModel.isFollowingUser = false
                                     } catch(let error) {
                                         print(error)
                                     }
                                 } else {
                                     do {
-                                        try await viewModel.requestToFollowUser(who: user.login)
-                                        viewModel.isFollowingUser = true
+                                        try await targetUserProfileViewModel.requestToFollowUser(who: user.login)
+                                        targetUserProfileViewModel.isFollowingUser = true
                                     } catch(let error) {
                                         print(error)
                                     }
                                 }
                             }
                         } label: {
-                            viewModel.isFollowingUser ?
+                            targetUserProfileViewModel.isFollowingUser ?
                             GSText.CustomTextView(style: .buttonTitle1, string: "✅ Following")
                                 .frame(maxWidth: .infinity)
                             :
@@ -293,15 +293,15 @@ struct TargetUserProfileView: View {
             targetUserInfo = await userInfoManager.requestUserInfoWithGitHubID(githubID: user.id)
             isGitSpaceUser = userInfoManager.users.contains { $0.githubLogin == self.user.login }
 
-            let readMeRequestResult = await viewModel.requestUserReadme(user: user.login)
-            let isFollowingTargetUser = await viewModel.checkAuthenticatedUserIsFollowing(who: user.login)
+            let readMeRequestResult = await targetUserProfileViewModel.requestUserReadme(user: user.login)
+            let isFollowingTargetUser = await targetUserProfileViewModel.checkAuthenticatedUserIsFollowing(who: user.login)
 
             if isFollowingTargetUser {
                 followButtonLable = "✅ Following"
-                viewModel.isFollowingUser = true
+                targetUserProfileViewModel.isFollowingUser = true
             } else {
                 followButtonLable = "➕ Follow"
-                viewModel.isFollowingUser = false
+                targetUserProfileViewModel.isFollowingUser = false
             }
 
             switch readMeRequestResult {


### PR DESCRIPTION
## 개요 및 관련 이슈
#394 
- 유저 블락 기능 사용시, BlockView에서 블락 버튼을 누른 뒤 블락했다는 사실을 알 수 있도록 TargetUserProfileView에 즉시 반영하였습니다. 

## 작업 사항
- TargetUserProfileView 및 BlockView에 State, Binding 변수 생성
- Block 버튼을 누르면 연결된 변수를 트리거로 사용하여 뷰에 반영
- 기존 GitHubUser 할당 로직을 private 함수로 변경
- 변수명 변경 

## 스크린샷

| BlockView 및 TargetUserProfileView | 
|:-------:|
| <img width="300" alt="gif" src="https://user-images.githubusercontent.com/19788294/235986284-e1744c2a-cc6c-4949-9745-4be68f2f55ea.gif">| 




