### PR TITLE
[Fix] 깃스페이스 유저가 아닌 경우 TargetUserProfileView에서 신고 메뉴 버튼(Ellipsis)가 보이지 않도록 처리하였습니다.

### DIFF
--- a/GitSpace/InitialView.swift
+++ b/GitSpace/InitialView.swift
@@ -11,6 +11,7 @@ import FirebaseAuth
 struct InitialView: View {
     @EnvironmentObject var githubAuthManager: GitHubAuthManager
     @EnvironmentObject var pushNotificationManager: PushNotificationManager
+    @StateObject var userStore = UserStore(currentUserID: Auth.auth().currentUser?.uid ?? "")
     let tabBarRouter: GSTabBarRouter
     
     // MARK: - 한호
@@ -35,7 +36,7 @@ struct InitialView: View {
             case .signedIn:
                 ContentView(tabBarRouter: tabBarRouter)
                     .preferredColorScheme(selectedAppearance)
-                    .environmentObject(UserStore(currentUserID: Auth.auth().currentUser?.uid ?? ""))
+                    .environmentObject(userStore)
             case .pending:
                 LoadingProgressView()
                     .preferredColorScheme(selectedAppearance)

--- a/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
+++ b/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
@@ -322,11 +322,13 @@ struct TargetUserProfileView: View {
             if (isGitSpaceUser && userInfoManager.currentUser?.githubID != user.id) {
                 Menu {
                     Section {
-                        Button(role: .destructive, action: {
-                            /* Block 모달 뷰 appear */
-                            isBlockViewShowing.toggle()
-                        }) {
-                            Label("Block", systemImage: "nosign")
+                        if !blockedUsers.blockedUserList.contains(where: { $0.gitHubUser == user }) {
+                            Button(role: .destructive, action: {
+                                /* Block 모달 뷰 appear */
+                                isBlockViewShowing.toggle()
+                            }) {
+                                Label("Block", systemImage: "nosign")
+                            }
                         }
                         
                         Button(role: .destructive, action: {

--- a/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
+++ b/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
@@ -255,7 +255,7 @@ struct TargetUserProfileView: View {
                     .frame(height: 1)
                     .overlay(Color.gsGray3)
                     .padding(.vertical, 10)
-
+                
                 // MARK: - 유저의 README
                 if isFailedToLoadReadme {
                     FailToLoadReadmeView()
@@ -288,11 +288,11 @@ struct TargetUserProfileView: View {
             } else {
                 isBlockedUser = false
             }
+            isGitSpaceUser = userInfoManager.users.contains { $0.githubID == user.id }
         }
             .task {
             targetUserInfo = await userInfoManager.requestUserInfoWithGitHubID(githubID: user.id)
-            isGitSpaceUser = userInfoManager.users.contains { $0.githubLogin == self.user.login }
-
+            
             let readMeRequestResult = await viewModel.requestUserReadme(user: user.login)
             let isFollowingTargetUser = await viewModel.checkAuthenticatedUserIsFollowing(who: user.login)
 

--- a/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
+++ b/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
@@ -11,12 +11,12 @@ import RichText
 // MARK: - gitHubUser 필요
 
 struct TargetUserProfileView: View {
-
+    
     @EnvironmentObject var gitHubAuthManager: GitHubAuthManager
     @EnvironmentObject var userInfoManager: UserStore
     @EnvironmentObject var blockedUsers: BlockedUsers
     @StateObject var viewModel = TargetUserProfileViewModel(gitHubService: GitHubService())
-
+    
     @State private var markdownString = ""
     @State private var followButtonLable: String = "➕ Follow"
     @State private var isShowingKnockSheet: Bool = false
@@ -28,18 +28,18 @@ struct TargetUserProfileView: View {
     @State private var isSuggestBlockViewShowing = false
     @State private var targetUserInfo: UserInfo? = nil
     @State private var isBlockedUser: Bool = false
-
+    
     let user: GithubUser
     let gitHubService = GitHubService()
-
+    
     init(user: GithubUser) {
         self.user = user
     }
-
+    
     var body: some View {
-
+        
         ScrollView(showsIndicators: false) {
-
+            
             if isBlockedUser {
                 VStack {
                     GSText.CustomTextView(style: .title3, string: "This user is blocked user")
@@ -52,7 +52,7 @@ struct TargetUserProfileView: View {
             }
             
             VStack(spacing: 8) {
-
+                
                 VStack(alignment: .leading) {
                     // MARK: -사람 이미지와 이름, 닉네임 등을 위한 stack.
                     HStack(spacing: 10) {
@@ -71,25 +71,25 @@ struct TargetUserProfileView: View {
                         }
                         Spacer()
                     }
-                        .padding(.bottom, 5)
-
+                    .padding(.bottom, 5)
+                    
                     if let bio = user.bio {
                         // MARK: - bio
                         HStack() {
                             GSText.CustomTextView(style: .body1, string: bio)
                             Spacer()
                         }
-                            .padding(15)
-                            .font(.callout)
-                            .frame(maxWidth: .infinity)
-                            .multilineTextAlignment(.leading)
-                            .background(Color.gsGray3)
-                            .clipShape(
+                        .padding(15)
+                        .font(.callout)
+                        .frame(maxWidth: .infinity)
+                        .multilineTextAlignment(.leading)
+                        .background(Color.gsGray3)
+                        .clipShape(
                             RoundedRectangle(cornerRadius: 10, style: .continuous)
                         )
-                            .padding(.vertical, 10)
+                        .padding(.vertical, 10)
                     }
-
+                    
                     if let company = user.company {
                         // MARK: - 소속
                         HStack {
@@ -98,11 +98,11 @@ struct TargetUserProfileView: View {
                                 .aspectRatio(contentMode: .fit)
                                 .frame(width: 15, height: 15)
                                 .foregroundColor(.gsGray2)
-
+                            
                             GSText.CustomTextView(style: .captionPrimary1, string: company)
                         }
                     }
-
+                    
                     if let location = user.location {
                         // MARK: - 위치 이미지, 국가 및 위치
                         HStack {
@@ -111,11 +111,11 @@ struct TargetUserProfileView: View {
                                 .aspectRatio(contentMode: .fit)
                                 .frame(width: 15, height: 15)
                                 .foregroundColor(.gsGray2)
-
+                            
                             GSText.CustomTextView(style: .captionPrimary1, string: location)
                         }
                     }
-
+                    
                     if let blogURLString = user.blog, blogURLString != "" {
                         // MARK: - 링크 이미지, 블로그 및 기타 링크
                         HStack {
@@ -124,7 +124,7 @@ struct TargetUserProfileView: View {
                                 .aspectRatio(contentMode: .fit)
                                 .frame(width: 15, height: 15)
                                 .foregroundColor(.gsGray2)
-
+                            
                             if let blogURL = URL(string: blogURLString) {
                                 Link(destination: blogURL) {
                                     GSText.CustomTextView(style: .captionPrimary1, string: blogURLString)
@@ -132,7 +132,7 @@ struct TargetUserProfileView: View {
                             }
                         }
                     }
-
+                    
                     // MARK: - 사람 심볼, 팔로워 및 팔로잉 수
                     HStack {
                         Image(systemName: "person")
@@ -140,7 +140,7 @@ struct TargetUserProfileView: View {
                             .aspectRatio(contentMode: .fit)
                             .frame(width: 15, height: 15)
                             .foregroundColor(.gsGray2)
-
+                        
                         NavigationLink {
                             TargetUserFollowerListView(service: gitHubService, targetUserLogin: user.login, followers: user.followers)
                         } label: {
@@ -167,11 +167,11 @@ struct TargetUserProfileView: View {
                         } // NavigationLink
                     }
                 }
-
+                
                 // 내 프로필인지 아닌지에 따라 분기처리
                 if user.login != gitHubAuthManager.authenticatedUser?.login {
                     // MARK: - follow, knock 버튼을 위한 stack
-
+                    
                     // GitSpaceUser라면 팔로우/팔로잉, 노크 버튼 다 보여주고 아니라면 팔로우/팔로잉 버튼만 보이기
                     if isGitSpaceUser {
                         HStack {
@@ -202,13 +202,13 @@ struct TargetUserProfileView: View {
                                 GSText.CustomTextView(style: .buttonTitle1, string: "✅ Following")
                                     .frame(maxWidth: .infinity)
                                 :
-                                    GSText.CustomTextView(style: .buttonTitle1, string: "➕ Follow")
+                                GSText.CustomTextView(style: .buttonTitle1, string: "➕ Follow")
                                     .frame(maxWidth: .infinity)
                             }
-
+                            
                             Spacer()
                                 .frame(width: 10)
-
+                            
                             GSNavigationLink(style: .secondary) {
                                 KnockCommunicationRouter(targetGithubUser: user)
                             } label: {
@@ -216,7 +216,7 @@ struct TargetUserProfileView: View {
                                     .frame(maxWidth: .infinity)
                             }
                         }
-                            .padding(.vertical, 10)
+                        .padding(.vertical, 10)
                     } else {
                         GSButton.CustomButtonView(
                             style: .secondary(isDisabled: false)
@@ -244,13 +244,13 @@ struct TargetUserProfileView: View {
                             GSText.CustomTextView(style: .buttonTitle1, string: "✅ Following")
                                 .frame(maxWidth: .infinity)
                             :
-                                GSText.CustomTextView(style: .buttonTitle1, string: "➕ Follow")
+                            GSText.CustomTextView(style: .buttonTitle1, string: "➕ Follow")
                                 .frame(maxWidth: .infinity)
                         }
-                            .padding(.vertical, 10)
+                        .padding(.vertical, 10)
                     }
                 }
-
+                
                 Divider()
                     .frame(height: 1)
                     .overlay(Color.gsGray3)
@@ -267,18 +267,18 @@ struct TargetUserProfileView: View {
                             GSText.CustomTextView(style: .caption2, string: "README.md")
                             Spacer()
                         }
-
+                        
                         RichText(html: markdownString)
                             .colorScheme(.auto)
                             .fontType(.system)
                             .linkOpenType(.SFSafariView())
                             .placeholder {
-                            ReadmeLoadingView()
-                        }
+                                ReadmeLoadingView()
+                            }
                     }
                 }
             }
-                .padding(.horizontal, 20)
+            .padding(.horizontal, 20)
         }
         .onAppear {
             if blockedUsers.blockedUserList.contains(where: {
@@ -290,12 +290,12 @@ struct TargetUserProfileView: View {
             }
             isGitSpaceUser = userInfoManager.users.contains { $0.githubID == user.id }
         }
-            .task {
+        .task {
             targetUserInfo = await userInfoManager.requestUserInfoWithGitHubID(githubID: user.id)
             
             let readMeRequestResult = await viewModel.requestUserReadme(user: user.login)
             let isFollowingTargetUser = await viewModel.checkAuthenticatedUserIsFollowing(who: user.login)
-
+            
             if isFollowingTargetUser {
                 followButtonLable = "✅ Following"
                 viewModel.isFollowingUser = true
@@ -303,7 +303,7 @@ struct TargetUserProfileView: View {
                 followButtonLable = "➕ Follow"
                 viewModel.isFollowingUser = false
             }
-
+            
             switch readMeRequestResult {
             case .success(let readmeString):
                 markdownString = readmeString
@@ -314,11 +314,12 @@ struct TargetUserProfileView: View {
                 case .unexpectedStatusCode:
                     isEmptyReadme = true
                 default:
-                   break
+                    break
                 }
             }
         }
-            .toolbar {
+        .toolbar {
+            if (isGitSpaceUser && userInfoManager.currentUser?.githubID != user.id) {
                 Menu {
                     Section {
                         Button(role: .destructive, action: {
@@ -340,18 +341,19 @@ struct TargetUserProfileView: View {
                         .frame(width: 40, height: 40)
                 }
             }
-            .halfSheet(isPresented: $isBlockViewShowing) {
-                if let targetUserInfo {
-                    BlockView(isBlockViewShowing: $isBlockViewShowing, targetUser: targetUserInfo)
-                        .environmentObject(userInfoManager)
-                        .environmentObject(blockedUsers)
-                }
+        }
+        .halfSheet(isPresented: $isBlockViewShowing) {
+            if let targetUserInfo {
+                BlockView(isBlockViewShowing: $isBlockViewShowing, targetUser: targetUserInfo)
+                    .environmentObject(userInfoManager)
+                    .environmentObject(blockedUsers)
             }
-            .halfSheet(isPresented: $isReportViewShowing) {
-                ReportView(isReportViewShowing: $isReportViewShowing, isSuggestBlockViewShowing: $isSuggestBlockViewShowing)
-            }
-            .halfSheet(isPresented: $isSuggestBlockViewShowing) {
-                SuggestBlockView(isBlockViewShowing: $isBlockViewShowing, isSuggestBlockViewShowing: $isSuggestBlockViewShowing)
-            }
+        }
+        .halfSheet(isPresented: $isReportViewShowing) {
+            ReportView(isReportViewShowing: $isReportViewShowing, isSuggestBlockViewShowing: $isSuggestBlockViewShowing)
+        }
+        .halfSheet(isPresented: $isSuggestBlockViewShowing) {
+            SuggestBlockView(isBlockViewShowing: $isBlockViewShowing, isSuggestBlockViewShowing: $isSuggestBlockViewShowing)
+        }
     } //  body
 }


### PR DESCRIPTION
## 개요 및 관련 이슈
- #393 


## 작업 사항
- 기존 깃스페이스 유저 확인 로직이 잘 작동하는지 확인
  - GitSpace 유저인지 확인하는 작업이 랜덤하게 작동하는 현상 발생
  - RepositoryDetailView에서 TargetUserProfileView 진입시에는 잘 작동하다가, ChatRoomView를 통해 TargetUserProfileView를 진입하면 로직이 작동하지 않음
  - GitSpace 유저 검증 로직 자체에는 문제가 없으나, UserStore 클래스의 Published 배열인 users가 초기화 되는 현상으로 파악되었습니다.
  - 따라서 InitialView에서 **UserStore 클래스의 인스턴스를 직접 생성하여** .environmentObject() 수정자로 등록하던 코드를 아래와 같이 변경하였습니다.
  - **UserStore 클래스의 인스턴스를 StateObject로 선언한 뒤**, .environmentObject() 수정자로 등록하여 Published 배열인 users가 초기화 되지 않도록 변경
  - 이제 다양한 뷰에서 접근해도 TargetUserProfileView에서 GitSpace 유저인지 검증하는 로직이 정상 작동합니다.
- GitSpace 유저 검증 로직 수행 후 깃스페이스 유저가 아니거나, 현재 사용자인 경우 차단/신고 메뉴 버튼(Ellipsis)를 제거하였습니다.
- 이미 블락된 유저인 경우, 메뉴에서 block 버튼이 나타나지 않도록 처리하였습니다.

## 스크린샷

| view | 수정 이전 | 수정 이후 | 
|:-------:|:-------:|:-------:|
| GitSpace 유저 검증 로직 여부 |<img width="200" src="https://user-images.githubusercontent.com/19788294/236128018-91b168d7-4fe9-4947-a66b-c6d15f715714.png"> | <img width="200" src="https://user-images.githubusercontent.com/19788294/236128133-961092e2-d132-4ade-8540-cb7ec94a7b55.png" > | 
| GitSpace 유저 검증 로직을 적용한 뒤 Menu | <img width="200" src="https://user-images.githubusercontent.com/19788294/236129745-c080299e-e8d8-46de-8f01-7fdad490b4a7.png"> |<img width="200" src="https://user-images.githubusercontent.com/19788294/236129640-826e5df5-5a09-4181-b092-9d4d8415ff18.png"> |
| 블락된 유저의 경우 Menu | <img width="200" src="https://user-images.githubusercontent.com/19788294/236130216-ad557688-1564-4d07-b25a-dfff86f8a4d9.png"> | <img width="200" src="https://user-images.githubusercontent.com/19788294/236130308-ca6b36fa-8590-4b2a-9f45-26ee3faf3c3d.png"> |


