### PR TITLE
[Feat] 앱 실행시, Current User의 Blocked Users를 불러오는 메서드를 구현하고 적용했습니다.

### DIFF
--- a/GitSpace/Sources/Network/Interface/Blockable.swift
+++ b/GitSpace/Sources/Network/Interface/Blockable.swift
@@ -137,3 +137,7 @@ enum BlockError: Error {
     case blockCreateFailed
     case unblockDeleteFailed
 }
+
+class BlockedUsers: ObservableObject {
+    @Published var blockedUserList: [(userInfo: UserInfo, gitHubUser: GithubUser)] = []
+}

--- a/GitSpace/Sources/Router/ContentView.swift
+++ b/GitSpace/Sources/Router/ContentView.swift
@@ -111,6 +111,27 @@ struct ContentView: View {
 //        .padding(.bottom, 20)
     }
     
+    /**
+     currentUser의 BlockedUserList를 가져옵니다.
+     가져온 유저 목록은 blockedUsers의 blockedUserList에 저장됩니다.
+     - blockedUsers.blockedUserList: [(userInfo, gitHubUser)]
+     - Author: 한호
+     */
+    private func retrieveBlockedUserList() async {
+        if let currentUser = await userStore.requestUserInfoWithID(userID: userStore.currentUser?.id ?? "") {
+            
+            for someUser in currentUser.blockedUserIDs {
+                if let userInfo = await UserStore.requestAndReturnUser(userID: someUser) {
+                    let gitHubUser = githubAuthManager.getGithubUser(FBUser: userInfo)
+                    let blockedUser: (userInfo: UserInfo, gitHubUser: GithubUser) = (userInfo, gitHubUser)
+                    
+                    if !blockedUsers.blockedUserList.contains(where: { $0.userInfo.id == userInfo.id }) {
+                        blockedUsers.blockedUserList.append(blockedUser)
+                    }
+                }
+            }
+        }
+    }
 }
 //
 //struct ContentView_Previews: PreviewProvider {

--- a/GitSpace/Sources/Router/ContentView.swift
+++ b/GitSpace/Sources/Router/ContentView.swift
@@ -20,6 +20,7 @@ struct ContentView: View {
     @EnvironmentObject var githubAuthManager: GitHubAuthManager
 	@EnvironmentObject var pushNotificationManager: PushNotificationManager
 	@EnvironmentObject var chatStore: ChatStore
+    @EnvironmentObject var blockedUsers: BlockedUsers
     
     var body: some View {
         /**

--- a/GitSpace/Sources/Router/ContentView.swift
+++ b/GitSpace/Sources/Router/ContentView.swift
@@ -68,6 +68,8 @@ struct ContentView: View {
                 Utility.loginUserID = uid
                 await userStore.requestUser(userID: uid)
                 await userStore.requestUsers()
+                
+                await retrieveBlockedUserList()
             
             } else {
                 print("Error-ContentView-requestUser : Authentication의 uid가 존재하지 않습니다.")

--- a/GitSpace/Sources/Views/Settings/Account/BlockedUsersListView.swift
+++ b/GitSpace/Sources/Views/Settings/Account/BlockedUsersListView.swift
@@ -77,10 +77,6 @@ struct BlockedUsersListView: View {
     }
 }
 
-class BlockedUsers: ObservableObject {
-    @Published var blockedUserList: [(userInfo: UserInfo, gitHubUser: GithubUser)] = []
-}
-
 struct BlockedUsersListView_Previews: PreviewProvider {
     static var previews: some View {
         BlockedUsersListView()

--- a/GitSpace/Sources/Views/Settings/Account/BlockedUsersListView.swift
+++ b/GitSpace/Sources/Views/Settings/Account/BlockedUsersListView.swift
@@ -44,9 +44,7 @@ struct BlockedUsersListView: View {
             }
         } //VStack
         .navigationBarTitle("Blocked users", displayMode: .inline)
-        .onViewDidLoad {
-            Task {
-                await convertUserInfo()
+    }
     
     /**
      currentUser의 BlockedUserList를 가져옵니다.

--- a/GitSpace/Sources/Views/Settings/Account/BlockedUsersListView.swift
+++ b/GitSpace/Sources/Views/Settings/Account/BlockedUsersListView.swift
@@ -13,9 +13,41 @@ struct BlockedUsersListView: View {
     @EnvironmentObject var gitHubAuthManager: GitHubAuthManager
     @EnvironmentObject var userInfoManager: UserStore
     @EnvironmentObject var blockedUsers: BlockedUsers
-    @State var isLoaded: Bool = false
+    @State var isLoaded: Bool = true
     
-    func convertUserInfo() async {
+    var body: some View {
+        VStack {
+            if isLoaded {
+                if !blockedUsers.blockedUserList.isEmpty {
+                    ScrollView {
+                        ForEach(blockedUsers.blockedUserList, id: \.userInfo.id) { blockedUser in
+                            BlockedUsersListCell(
+                                userInfo: blockedUser.userInfo,
+                                gitHubUser: blockedUser.gitHubUser
+                            )
+                        }
+                    } // ScrollView
+                    .refreshable {
+                        await retrieveBlockedUserList()
+                    }
+                } else {
+                    VStack {
+                        Spacer()
+                        GSText.CustomTextView(
+                            style: .description2,
+                            string: "You haven't blocked anyone.")
+                        Spacer()
+                    }
+                }
+            } else {
+                BlockedUsersListSkeletonView()
+            }
+        } //VStack
+        .navigationBarTitle("Blocked users", displayMode: .inline)
+        .onViewDidLoad {
+            Task {
+                await convertUserInfo()
+    private func retrieveBlockedUserList() async {
         
         withAnimation(.easeInOut) {
             isLoaded = false
@@ -37,42 +69,6 @@ struct BlockedUsersListView: View {
         
         withAnimation(.easeInOut) {
             isLoaded = true
-        }
-    }
-    
-    var body: some View {
-        VStack {
-            if isLoaded {
-                if !blockedUsers.blockedUserList.isEmpty {
-                    ScrollView {
-                        ForEach(blockedUsers.blockedUserList, id: \.userInfo.id) { blockedUser in
-                            BlockedUsersListCell(
-                                userInfo: blockedUser.userInfo,
-                                gitHubUser: blockedUser.gitHubUser
-                            )
-                        }
-                    } // ScrollView
-                    .refreshable {
-                        await convertUserInfo()
-                    }
-                } else {
-                    VStack {
-                        Spacer()
-                        GSText.CustomTextView(
-                            style: .description2,
-                            string: "You haven't blocked anyone.")
-                        Spacer()
-                    }
-                }
-            } else {
-                BlockedUsersListSkeletonView()
-            }
-        } //VStack
-        .navigationBarTitle("Blocked users", displayMode: .inline)
-        .onViewDidLoad {
-            Task {
-                await convertUserInfo()
-            }
         }
     }
 }

--- a/GitSpace/Sources/Views/Settings/Account/BlockedUsersListView.swift
+++ b/GitSpace/Sources/Views/Settings/Account/BlockedUsersListView.swift
@@ -47,6 +47,14 @@ struct BlockedUsersListView: View {
         .onViewDidLoad {
             Task {
                 await convertUserInfo()
+    
+    /**
+     currentUser의 BlockedUserList를 가져옵니다.
+     가져온 유저 목록은 blockedUsers의 blockedUserList에 저장됩니다.
+     isLoaded가 false일 동안 스켈레톤 뷰가 노출됩니다.
+     - blockedUsers.blockedUserList: [(userInfo, gitHubUser)]
+     - Author: 한호
+     */
     private func retrieveBlockedUserList() async {
         
         withAnimation(.easeInOut) {

--- a/GitSpace/Sources/Views/Settings/Account/SetAccountView.swift
+++ b/GitSpace/Sources/Views/Settings/Account/SetAccountView.swift
@@ -43,13 +43,13 @@ struct SetAccountView: View {
                 }
             } // Section
             
-            // MARK: Logout / Delete Account
+            // MARK: Sign out / Delete Account
             /// 로그아웃 / 계정 삭제
             Section {
                 Button(role: .cancel) {
                     showingLogoutAlert.toggle()
                 } label: {
-                    Text("Logout")
+                    Text("Sign out")
                 }
                 
                 Button(role: .destructive) {
@@ -64,12 +64,12 @@ struct SetAccountView: View {
             
         } // List
         .navigationBarTitle("Account", displayMode: .inline)
-        .alert("Logout", isPresented: $showingLogoutAlert) {
-              Button("Logout", role: .destructive) {
+        .alert("Sign out", isPresented: $showingLogoutAlert) {
+              Button("Sign out", role: .destructive) {
                   gitHubAuthManager.signOut()
               }
         } message: {
-            Text("Logout from ") + Text("@\(gitHubAuthManager.authenticatedUser?.login ?? "") ").bold() + Text("account.")
+            Text("Sign out from ") + Text("@\(gitHubAuthManager.authenticatedUser?.login ?? "") ").bold() + Text("account.")
         }
         .alert("Delete Account", isPresented: $showingDeleteAccountAlert) {
               Button("Delete", role: .destructive) {
@@ -79,7 +79,7 @@ struct SetAccountView: View {
                   }
               }
         } message: {
-            Text("@\(gitHubAuthManager.authenticatedUser?.login ?? "") ").bold() + Text("account has been deleted.")
+            Text("@\(gitHubAuthManager.authenticatedUser?.login ?? "") ").bold() + Text("account will be deleted.\nAre you sure?")
         }
     }
 }


### PR DESCRIPTION
## 개요 및 관련 이슈
- 앱 실행시, Current User의 Blocked Users를 불러오는 메서드를 구현하고 적용했습니다.
- #398 

## 작업 사항
- `BlockedUsersListView`의 `convertUserInfo()` 메서드의 이름을 변경했습니다.
  `convertUserInfo()` -> `retrieveBlockedUserList()`
- `ContentView`에도 `retrieveBlockedUserList()` 메서드를 추가하여 앱이 실행 될 때 메서드가 동작할 수 있게 하였습니다.
- `BlockedUsers` 클래스의 위치를 변경했습니다.
  `BlockedUsersListView.swift` -> `Blockable.swift`

## 작업 결과
- 기존에는 `BlockedUsersListView`에 진입해야 `BlockedUsers`에 currentUser가 Blocked Users가 불러와졌지만,
이제는 앱 실행시 `retrieveBlockedUserList()` 메서드가 호출되며 Blocked Users를 불러옵니다.
- 차단한 유저의 프로필 방문시 "This user is blocked user" 문구가 정상적으로 노출되는 것을 확인했습니다.
