### PR TITLE
[Feat] 회원 탈퇴 시 로컬 데이터를 초기화하는 기능을 추가했습니다.

### DIFF
--- a/GitSpace/Sources/ViewModels/ChatViewModel.swift
+++ b/GitSpace/Sources/ViewModels/ChatViewModel.swift
@@ -46,7 +46,6 @@ final class ChatStore: ObservableObject {
     private var listener: ListenerRegistration?
     private let db = Firestore.firestore()
     private let const = Constant.FirestorePathConst.self
-	
     var targetUserInfoDict: [String: UserInfo]
     
 	@Published var newChat: Chat
@@ -179,6 +178,11 @@ extension ChatStore {
     private func writeChats(chats: [Chat]) {
         self.chats = chats
         self.isDoneFetch = true
+    }
+    
+    @MainActor
+    func removeChatList() {
+        chats.removeAll()
     }
     
     func fetchChats() async {

--- a/GitSpace/Sources/ViewModels/KnockHistory/KnockViewManager.swift
+++ b/GitSpace/Sources/ViewModels/KnockHistory/KnockViewManager.swift
@@ -247,7 +247,7 @@ extension KnockViewManager {
 			}
 	}
 	
-	private func removeSnapshot() {
+	func removeSnapshot() {
 		if let listener {
 			listener.remove()
 		}

--- a/GitSpace/Sources/ViewModels/KnockHistory/KnockViewManager.swift
+++ b/GitSpace/Sources/ViewModels/KnockHistory/KnockViewManager.swift
@@ -394,7 +394,7 @@ extension KnockViewManager {
     }
     
     @MainActor
-    private func removeKnockList() {
+    func removeKnockList() {
         receivedKnockList.removeAll()
         sentKnockList.removeAll()
     }

--- a/GitSpace/Sources/Views/Chat/MainChat/MainChatView.swift
+++ b/GitSpace/Sources/Views/Chat/MainChat/MainChatView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct MainChatView: View {
     
-    let gitHubService = GitHubService()
+    private let gitHubService = GitHubService()
     
     @EnvironmentObject var chatStore : ChatStore
     //@StateObject var followerViewModel = FollowerViewModel()

--- a/GitSpace/Sources/Views/Settings/Account/SetAccountView.swift
+++ b/GitSpace/Sources/Views/Settings/Account/SetAccountView.swift
@@ -88,6 +88,8 @@ struct SetAccountView: View {
     }
     
     private func reset() {
+        chatViewModel.removeListener()
+        knockViewManager.removeSnapshot()
         chatViewModel.removeChatList()
         knockViewManager.removeKnockList()
     }

--- a/GitSpace/Sources/Views/Settings/Account/SetAccountView.swift
+++ b/GitSpace/Sources/Views/Settings/Account/SetAccountView.swift
@@ -92,6 +92,7 @@ struct SetAccountView: View {
         knockViewManager.removeSnapshot()
         chatViewModel.removeChatList()
         knockViewManager.removeKnockList()
+        chatViewModel.isDoneFetch = false
     }
 }
 

--- a/GitSpace/Sources/Views/Settings/Account/SetAccountView.swift
+++ b/GitSpace/Sources/Views/Settings/Account/SetAccountView.swift
@@ -83,7 +83,7 @@ struct SetAccountView: View {
                   }
               }
         } message: {
-            Text("@\(gitHubAuthManager.authenticatedUser?.login ?? "") ").bold() + Text("account has been deleted.")
+            Text("@\(gitHubAuthManager.authenticatedUser?.login ?? "") ").bold() + Text("account would be deleted.")
         }
     }
     

--- a/GitSpace/Sources/Views/Settings/Account/SetAccountView.swift
+++ b/GitSpace/Sources/Views/Settings/Account/SetAccountView.swift
@@ -14,6 +14,9 @@ struct SetAccountView: View {
     @State private var showingLogoutAlert = false
     @State private var showingDeleteAccountAlert = false
     
+    @EnvironmentObject private var chatViewModel: ChatStore
+    @EnvironmentObject private var knockViewManager: KnockViewManager
+    
     var body: some View {
         List {
             // MARK: - APP MANAGEMENT
@@ -76,11 +79,17 @@ struct SetAccountView: View {
                   Task {
                       await gitHubAuthManager.deleteCurrentUser()
                       await gitHubAuthManager.withdrawal()
+                      reset()
                   }
               }
         } message: {
             Text("@\(gitHubAuthManager.authenticatedUser?.login ?? "") ").bold() + Text("account has been deleted.")
         }
+    }
+    
+    private func reset() {
+        chatViewModel.removeChatList()
+        knockViewManager.removeKnockList()
     }
 }
 


### PR DESCRIPTION
## 개요 및 관련 이슈
- Chat, Knock 등 일부 ViewModel에서는 Firestore 읽기 최적화를 위해 최초 1회에만 Request 하도록 구현되어있습니다.
- 현재 회원 탈퇴 시 로컬 ViewModel에 남아있는 이전 유저의 데이터가 그대로 노출되는 현상이 있어 수정이 필요합니다.
- #405 

## 작업 사항
- 1회만 Request 하는 기존 ViewModel 로직 파악
- Reset 로직 구현

## 주요 로직
```swift
private func reset() {
    chatViewModel.removeChatList()
    knockViewManager.removeKnockList()
}
```
