### PR TITLE
Fix/#391, Fix/#390 knock profile image skeleton UI fix

### DIFF
--- a/GitSpace/Sources/Models/UserInfo.swift
+++ b/GitSpace/Sources/Models/UserInfo.swift
@@ -42,7 +42,7 @@ struct UserInfo : Identifiable, Codable, Equatable {
     }
 	
 	static func getFaliedUserInfo() -> Self {
-		let userinfo = UserInfo(id: "PJjxY5xHGZXXsMGqpyWExd50iDP2", createdDate: .now, deviceToken: "FALIED", blockedUserIDs: ["FALIED"], githubID: 0, githubLogin: "FALIED", githubName: "FALIED", githubEmail: "FALIED", avatar_url: "FALIED", bio: "FALIED", company: "FALIED", location: "FALIED", blog: "FALIED", public_repos: 0, followers: 0, following: 0)
+		let userinfo = UserInfo(id: "FAILED", createdDate: .now, deviceToken: "FAILED", blockedUserIDs: ["FAILED"], githubID: 0, githubLogin: "FAILED", githubName: "FAILED", githubEmail: "FAILED", avatar_url: "ProfilePlaceholder", bio: "FAILED", company: "FAILED", location: "FAILED", blog: "FAILED", public_repos: 0, followers: 0, following: 0)
 		return userinfo
 	}
 }

--- a/GitSpace/Sources/Router/ContentView.swift
+++ b/GitSpace/Sources/Router/ContentView.swift
@@ -51,7 +51,7 @@ struct ContentView: View {
                     .ignoresSafeArea(.keyboard, edges: .bottom)
                 }
             }
-            
+            .navigationViewStyle(.stack)
         }
         .task {
             // Authentication의 로그인 유저 uid를 받아와서 userStore의 유저 객체를 할당

--- a/GitSpace/Sources/ViewModels/UserViewModel.swift
+++ b/GitSpace/Sources/ViewModels/UserViewModel.swift
@@ -83,10 +83,13 @@ final class UserStore: ObservableObject {
             print(#file, #function, "USERID:", userID)
 			let userInfo = try await doc.getDocument(as: UserInfo.self)
 			return userInfo
-		} catch {
-			dump("\(#file), \(#function) - DEBUG \(error.localizedDescription)")
-			return nil
-		}
+        } catch is FirestoreErrorCode { // Firestore Error 일 경우
+            dump("\(#file), \(#function) - DEBUG: FIRESTORE ERROR")
+            return UserInfo.getFaliedUserInfo()
+        } catch { // 내부 인코딩-디코딩 Error일 경우
+            dump("\(#file), \(#function) - DEBUG: \(error.localizedDescription)")
+            return UserInfo.getFaliedUserInfo()
+        }
 	}
 	
 	/**

--- a/GitSpace/Sources/Views/Knock/MainKnockBox/EachKnockCell.swift
+++ b/GitSpace/Sources/Views/Knock/MainKnockBox/EachKnockCell.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct EachKnockCell: View {
     @EnvironmentObject var knockViewManager: KnockViewManager
     @EnvironmentObject var userInfoManager: UserStore
-	@Binding var eachKnock: Knock
+    @Binding var eachKnock: Knock
     @Binding var isEditing: Bool
     @State private var targetUserInfo: UserInfo? = nil
     @State private var isChecked: Bool = false
@@ -18,42 +18,45 @@ struct EachKnockCell: View {
     
     // MARK: Binding하면 상위 state에 의해 이름 잔상 애니메이션이 남는다.
     @State var userSelectedTab: String
-	
-	// MARK: - body
+    
+    // MARK: - body
     var body: some View {
-		VStack {
-			HStack(alignment: .center) {
-				if isEditing {
-					Image(systemName: isChecked ? "checkmark.circle.fill" : "circle")
-						.resizable()
-						.aspectRatio(contentMode: .fit)
-						.frame(width: 30, height: 30)
-						.foregroundColor(isChecked ? Color(UIColor.systemBlue) : Color.secondary)
-						.onTapGesture {
-							self.isChecked.toggle()
-						}
-				}
-				
-                if let targetUserInfo {
+        VStack {
+            HStack(alignment: .center) {
+                if isEditing {
+                    Image(systemName: isChecked ? "checkmark.circle.fill" : "circle")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 30, height: 30)
+                        .foregroundColor(isChecked ? Color(UIColor.systemBlue) : Color.secondary)
+                        .onTapGesture {
+                            self.isChecked.toggle()
+                        }
+                }
+                
+                if
+                    let targetUserInfo,
+                    targetUserInfo.avatar_url != "ProfilePlaceholder" {
                     GithubProfileImage(
                         urlStr: targetUserInfo.avatar_url,
                         size: 50
                     )
+                } else if
+                    let targetUserInfo,
+                    targetUserInfo.avatar_url == "ProfilePlaceholder" {
+                    DefaultProfileImage(size: 50)
                 } else {
-                    Image("ProfilePlaceholder")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .clipShape(Circle())
-                        .frame(width: 50)
-                        .modifier(BlinkingSkeletonModifier(
-                            opacity: opacity,
-                            shouldShow: true
-                        )
+                    DefaultProfileImage(size: 50)
+                        .modifier(
+                            BlinkingSkeletonModifier(
+                                opacity: opacity,
+                                shouldShow: true
+                            )
                         )
                 }
-				
-				VStack {
-					HStack {
+                
+                VStack {
+                    HStack {
                         if userSelectedTab == Constant.KNOCK_RECEIVED {
                             Text("from: **\(eachKnock.sentUserName)**")
                                 .font(.body)
@@ -63,52 +66,53 @@ struct EachKnockCell: View {
                                 .font(.body)
                                 .id(eachKnock.receivedUserName)
                         }
-						
-						Spacer()
-						
+                        
+                        Spacer()
+                        
                         Text("\(eachKnock.knockedDate.dateValue().timeAgoDisplay())")
-							.font(.subheadline)
-							.foregroundColor(Color(.systemGray))
-							.padding(.leading, -10)
+                            .font(.subheadline)
+                            .foregroundColor(Color(.systemGray))
+                            .padding(.leading, -10)
                             .id(eachKnock.knockedDate.dateValue().timeAgoDisplay())
-						
-						Image(systemName: "chevron.right")
-							.resizable()
-							.aspectRatio(contentMode: .fit)
-							.frame(width: 10, height: 10)
-							.foregroundColor(Color(.systemGray))
-						
-					} // HStack
-					
-					HStack {
-						Text(eachKnock.knockMessage)
-							.lineLimit(1)
-						
-						Spacer()
-						
-						if eachKnock.knockStatus == Constant.KNOCK_WAITING {
-							Text(eachKnock.knockStatus)
+                        
+                        Image(systemName: "chevron.right")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 10, height: 10)
+                            .foregroundColor(Color(.systemGray))
+                        
+                    } // HStack
+                    
+                    HStack {
+                        Text(eachKnock.knockMessage)
+                            .lineLimit(1)
+                        
+                        Spacer()
+                        
+                        if eachKnock.knockStatus == Constant.KNOCK_WAITING {
+                            Text(eachKnock.knockStatus)
                                 .foregroundColor(Color("GSPurple"))
-						} else if eachKnock.knockStatus == Constant.KNOCK_ACCEPTED {
-							Text(eachKnock.knockStatus)
-								.foregroundColor(Color.accentColor)
-						} else {
-							Text("\(eachKnock.knockStatus)")
-								.foregroundColor(Color("GSRed"))
-						}
-					} // HStack
-					.font(.subheadline)
-					.foregroundColor(Color(.systemGray))
-					
-				} // VStack
-				
-			} // HStack
-			.padding(.vertical, 5)
-			.padding(.horizontal)
-			
-			Divider()
-				.padding(.horizontal, 20)
-		}
+                        } else if eachKnock.knockStatus == Constant.KNOCK_ACCEPTED {
+                            Text(eachKnock.knockStatus)
+                                .foregroundColor(Color.accentColor)
+                        } else {
+                            Text("\(eachKnock.knockStatus)")
+                                .foregroundColor(Color("GSRed"))
+                        }
+                    } // HStack
+                    .font(.subheadline)
+                    .foregroundColor(Color(.systemGray))
+                    
+                } // VStack
+                .id(eachKnock.id)
+                
+            } // HStack
+            .padding(.vertical, 5)
+            .padding(.horizontal)
+            
+            Divider()
+                .padding(.horizontal, 20)
+        }
         .task {
             withAnimation(
                 .linear(duration: 0.5).repeatForever(autoreverses: true)

--- a/GitSpace/Utilities/Constant.swift
+++ b/GitSpace/Utilities/Constant.swift
@@ -17,6 +17,10 @@ public enum Constant {
 	static let KNOCK_RECEIVED: String = "Received"
 	static let KNOCK_SENT: String = "Sent"
     
+    enum Assets {
+        static let PROFILE_PLACEHOLDER: String = "ProfilePlaceholder"
+    }
+    
 	/// AppStorage에 유저 설정을 저장할 때의 키값을 보관하는 상수 입니다.
 	enum AppStorageConst {
 		static let KNOCK_ALL_NOTIFICATION: String = "isAllKnockNotificationEnabled"


### PR DESCRIPTION
## 개요 및 관련 이슈
- #391 
- #390 

## 작업 사항
- NavigationView -> Stack Style 추가
    - Chat View Route에서 bound-back 되는 현상 해결
- SkeletonUI가 삭제된 유저를 대상으로 placeholderImage로 나오도록 수정
    - Animation이 걸리는 View에 id를 `knock.id`로 새로 할당

| User가 삭제되었을 때, <br> KnockHistoryView |
| :------: |
| ![](https://i.imgur.com/XFfFxFk.png) |

## 주요 로직(Optional)

```swift
// SKELETONUI 수정 부분
ZStack {
    Color.white
        .zIndex(0)
        .clipShape(Circle())

    // 아래 있는 코드의 뷰가 더 상위에 떠야하므로 zIndex 1
    Circle()
        .fill(.gray)
        .opacity(opacity)
        .zIndex(1)
}
.frame(width: 50)
.overlay {
    /// 만약 타겟유저가 fetch되고, 그 id 가 "FAILED"가 아닐 경우
    /// githubProfileImage를 그린다.
    if
        let targetUserInfo,
        targetUserInfo.id != "FAILED" {
        GithubProfileImage(
            urlStr: targetUserInfo.avatar_url,
            size: 50
        )
    }
    /// 만약 타겟유저가 fetch되고, 그 id 가 FAILED일 경우
    /// fetch가 실패했다는 의미로 DefaultProfileImage를 그린다.
    else if
        let targetUserInfo,
        targetUserInfo.id == "FAILED" {
        DefaultProfileImage(size: 50)
    }
}
```

---

