### PR TITLE
[Feat] 앱 내에 햅틱 피드백을 추가했습니다.

### DIFF
--- a/GitSpace/Sources/Views/Settings/AppSettings/SetAppearanceView.swift
+++ b/GitSpace/Sources/Views/Settings/AppSettings/SetAppearanceView.swift
@@ -50,6 +50,7 @@ struct SetAppearanceView: View {
             Button {
                 appearancePrint(item: item)
                 systemAppearance = item.rawValue
+                UIImpactFeedbackGenerator(style: .rigid).impactOccurred()
             } label: {
                 HStack {
                     Text("\(item.appearance)")

--- a/GitSpace/Utilities/Components/GSTabBarIcon.swift
+++ b/GitSpace/Utilities/Components/GSTabBarIcon.swift
@@ -63,6 +63,7 @@ struct GSTabBarIcon: View {
             .foregroundColor(colorScheme == .light ? .gsGreenPrimary : .gsYellowPrimary)
             .onTapGesture {
                 tabBarRouter.currentPage = page
+                UIImpactFeedbackGenerator(style: .rigid).impactOccurred()
             }
         }
 


### PR DESCRIPTION
## 개요 및 관련 이슈
- 앱 내에 햅틱 피드백을 추가했습니다.
- #408 

## 작업 사항
- 앱 내에 햅틱 피드백을 추가했습니다.
  - SetAppearanceView
  - GSTabBarIcon

## 주요 로직(Optional)
```diff
.onTapGesture {
    tabBarRouter.currentPage = page
+   UIImpactFeedbackGenerator(style: .rigid).impactOccurred()
}
```
