### PR TITLE
Fix/#65 design system button implement disabled

### DIFF
--- a/GitSpace/Resources/Assets.xcassets/GSGrayColors/GSgray1.colorset/Contents.json
+++ b/GitSpace/Resources/Assets.xcassets/GSGrayColors/GSgray1.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.592",
-          "green" : "0.561",
-          "red" : "0.553"
+          "blue" : "0x97",
+          "green" : "0x8F",
+          "red" : "0x8D"
         }
       },
       "idiom" : "universal"

--- a/GitSpace/Sources/Views/Chat/MainChat/ChatUserRecommendationSection.swift
+++ b/GitSpace/Sources/Views/Chat/MainChat/ChatUserRecommendationSection.swift
@@ -93,7 +93,7 @@ struct ChatUserRecommendationSection: View {
                             .frame(height: 20)
 
                         // MARK: - NewKnockView로 이동하는 챗 버튼
-                        GSNavigationLink(style: .secondary) {
+                        GSNavigationLink(style: .secondary()) {
 //                            SendKnockView()
 							Text("SENDKNOCKVIEW")
                         } label: {

--- a/GitSpace/Sources/Views/Common/TopperProfileView.swift
+++ b/GitSpace/Sources/Views/Common/TopperProfileView.swift
@@ -40,7 +40,7 @@ struct TopperProfileView: View {
             .foregroundColor(.gsLightGray2)
             
             // MARK: - 프로필 이동 버튼
-            GSNavigationLink(style: .secondary) {
+            GSNavigationLink(style: .secondary()) {
                 TargetUserProfileView(user: GithubUser(id: targetUserInfo.githubID, login: targetUserInfo.githubLogin, name: targetUserInfo.githubName, email: targetUserInfo.githubEmail, avatar_url: targetUserInfo.avatar_url, bio: targetUserInfo.bio, company: targetUserInfo.company, location: targetUserInfo.location, blog: targetUserInfo.blog, public_repos: targetUserInfo.public_repos, followers: targetUserInfo.followers, following: targetUserInfo.following))
             } label: {
                 Text("View Profile")

--- a/GitSpace/Sources/Views/Knock/MainKnockBox/KnockHistoryView.swift
+++ b/GitSpace/Sources/Views/Knock/MainKnockBox/KnockHistoryView.swift
@@ -169,7 +169,7 @@ struct KnockHistoryView: View {
                     let activatedChat,
                     let targetUserInfo {
                     GSNavigationLink(
-                        style: .secondary
+                        style: .secondary()
                     ) {
                         ChatRoomView(
                             chat: activatedChat,

--- a/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
+++ b/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
@@ -208,7 +208,7 @@ struct TargetUserProfileView: View {
                             Spacer()
                                 .frame(width: 10)
                             
-                            GSNavigationLink(style: .secondary) {
+                            GSNavigationLink(style: .secondary()) {
                                 KnockCommunicationRouter(targetGithubUser: user)
                             } label: {
                                 GSText.CustomTextView(style: .buttonTitle1, string: "Knock")

--- a/GitSpace/Utilities/Components/GSButton.swift
+++ b/GitSpace/Utilities/Components/GSButton.swift
@@ -32,16 +32,16 @@ public struct GSButton {
 				.buttonColorSchemeModifier(style: style)
 				
 				// MARK: - DONE
-			case .secondary:
+			case let .secondary(isDisabled):
 				Button(action: action) {
 					label
-						.labelHierarchyModifier(style: .secondary)
+						.labelHierarchyModifier(
+                            style: .secondary(
+                                isDisabled: isDisabled
+                            )
+                        )
 				}
-                // TODO: Button과 NavigationLink가 같은 secondary 스타일을 줘도 이 부분 코드가 달라서 다른 모양이 나오는 것으로 확인. 우선은 Navi쪽의 속성자와 동일하게 맞춤. 쥬니에게 확인 필요.
-//				.buttonColorSchemeModifier(style: style)
-                .buttonStyle(
-                    ViewHighlightColorStyle(style: .secondary)
-                )
+				.buttonColorSchemeModifier(style: style)
 				
 				// MARK: - TODO : 태그 액션과 상태 기획 정리되면 추가
 			case let .tag(isAppliedInView, isSelectedInAddTagSheet):
@@ -108,20 +108,50 @@ struct Test2: View {
 			VStack {
                 Text(isEditing.description)
                 
-				GSButton.CustomButtonView(
-					style: .tag(
-                        isAppliedInView: isSelected
-					)
-				) {
-					withAnimation {
-                        isEditing.toggle()
-					}
-				} label: {
-					Text("????")
-						.font(.callout)
-						.bold()
-				}
-				.tag("HI")
+                Button {
+                    isDisabled.toggle()
+                } label: {
+                    Text("\(isDisabled.description)")
+                }
+
+                
+                GSNavigationLink(style: .secondary()) {
+                    Text("?")
+                } label: {
+                    Text("?")
+                }
+                
+                GSButton.CustomButtonView(
+                    style: .secondary(isDisabled: isDisabled)
+                ) {
+                    print("??")
+                } label: {
+                    Text("HI")
+                }
+                
+                NavigationLink {
+                    Text("?")
+                } label: {
+                    Text("?")
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 10)
+                        .frame(minWidth: 80)
+//                        .frame(maxHeight: maxHeight)
+                }
+                .buttonBorderShape(.capsule)
+                .buttonStyle(.borderedProminent)
+
+                Button {
+                    print()
+                } label: {
+                    Text("?")
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 10)
+                        .frame(minWidth: 80)
+//                        .frame(maxHeight: maxHeight)
+                }
+                .buttonBorderShape(.capsule)
+                .buttonStyle(.borderedProminent)
 			}	
 		}
 	}

--- a/GitSpace/Utilities/Components/GSNavigationLink.swift
+++ b/GitSpace/Utilities/Components/GSNavigationLink.swift
@@ -20,7 +20,11 @@ struct GSNavigationLink<Destination: View, Label: View>: View {
 		case .primary:
 			navigationLinkBuilder(style: style)
 				.shadowColorSchemeModifier()
-			
+        
+        case let .secondary(_):
+            navigationLinkBuilder(style: style)
+                .shadowColorSchemeModifier()
+            
 		default:
 			navigationLinkBuilder(style: style)
 		}
@@ -50,33 +54,51 @@ struct GSNavigationLink<Destination: View, Label: View>: View {
             // 컬러스키마에 상관없이 검은 텍스트
                 .foregroundColor(.primary)
 		}
-		.buttonStyle(
-			ViewHighlightColorStyle(style: style)
-		)
+        .tint(colorSchemeBackgroundColor())
+		.buttonStyle(.borderedProminent)
+        .buttonBorderShape(.capsule)
 	}
+    
+    private func colorSchemeBackgroundColor() -> Color {
+        switch colorScheme {
+        case .light:
+            return Color.gsGreenPrimary
+        case .dark:
+            return Color.gsYellowPrimary
+        @unknown default:
+            return Color.clear
+        }
+    }
 }
 
 struct GSNavigationPreview: PreviewProvider {
 	static var previews: some View {
 		NavigationView {
 			VStack {
-				GSNavigationLink(style: .tertiary()) {
+//				GSNavigationLink(style: .tertiary()) {
+//					Text("?")
+//				} label: {
+//					Text("Hi")
+//				}
+//
+				GSNavigationLink(style: .secondary()) {
 					Text("?")
 				} label: {
 					Text("Hi")
 				}
+                
+                GSButton.CustomButtonView(style: .secondary(isDisabled: false)) {
+                    print()
+                } label: {
+                    Text("Hi")
+                }
+
 				
-				GSNavigationLink(style: .secondary) {
-					Text("?")
-				} label: {
-					Text("Hi")
-				}
-				
-				GSNavigationLink(style: .primary) {
-					Text("?")
-				} label: {
-					Text("Hi")
-				}
+//				GSNavigationLink(style: .primary) {
+//					Text("?")
+//				} label: {
+//					Text("Hi")
+//				}
 			}
 		}
 	}

--- a/GitSpace/Utilities/Constant.swift
+++ b/GitSpace/Utilities/Constant.swift
@@ -149,7 +149,7 @@ public enum Constant {
 
 	public enum LabelHierarchy {
 		case primary
-		case secondary
+        case secondary(isDisabled: Bool = false)
         // 전자의 연관값으로 흑백, 후자의 연관값으로 청노를 구분한다.
         case tertiary(
             isAppliedInView: Bool? = nil,

--- a/GitSpace/Utilities/Modifiers/GSButtonStyleModifiers.swift
+++ b/GitSpace/Utilities/Modifiers/GSButtonStyleModifiers.swift
@@ -22,14 +22,22 @@ public struct GSButtonStyleModifiers: ViewModifier {
 				content
 					.buttonBorderShape(.capsule)
 					.buttonStyle(.borderedProminent)
-					.tint(isDisabled ? .gsLightGray1 : .gsGreenPrimary)
+					.tint(isDisabled ? .gsGray1 : .gsGreenPrimary)
 					.shadowColorSchemeModifier()
 				
-			case .secondary(let isDisabled):
+			case let .secondary(isDisabled):
 				content
 					.buttonBorderShape(.capsule)
 					.buttonStyle(.borderedProminent)
-					.tint(isDisabled ? .gsLightGray1 : .gsGreenPrimary)
+                    .tint(isDisabled ? .gsGray1 : .gsGreenPrimary)
+                    .overlay {
+                        // Custom Disable 구현을 위해 .disabled() 대신 Capsule을 overlay 합니다.
+                        // why: .disabled() 는 systemGray를 자동으로 적용하는 이슈가 있음.
+                        if isDisabled {
+                            Capsule()
+                                .fill(.white.opacity(0.0001))
+                        }
+                    }
 					
 			case let .tag(isAppliedInView, isSelectedInAddTagSheet):
 				content
@@ -65,11 +73,19 @@ public struct GSButtonStyleModifiers: ViewModifier {
 					.tint(.gsYellowPrimary)
 					.shadowColorSchemeModifier()
 				
-			case .secondary:
-				content
-					.buttonBorderShape(.capsule)
-					.buttonStyle(.borderedProminent)
-					.tint(.gsYellowPrimary)
+            case let .secondary(isDisabled):
+                content
+                    .buttonBorderShape(.capsule)
+                    .buttonStyle(.borderedProminent)
+                    .tint(isDisabled ? .gsGray1 : .gsYellowPrimary)
+                    .overlay {
+                        // Custom Disable 구현을 위해 .disabled() 대신 Capsule을 overlay 합니다.
+                        // why: .disabled() 는 systemGray를 자동으로 적용하는 이슈가 있음.
+                        if isDisabled {
+                            Capsule()
+                                .fill(.white.opacity(0.0001))
+                        }
+                    }
 				
             case let .tag(isAppliedInView, isSelectedInAddTagSheet):
 				content

--- a/GitSpace/Utilities/Modifiers/LabelModifier.swift
+++ b/GitSpace/Utilities/Modifiers/LabelModifier.swift
@@ -23,9 +23,9 @@ struct GSLabelModifier: ViewModifier {
 				.frame(minWidth: 150)
 				.frame(maxHeight: maxHeight)
 				
-		case .secondary:
+		case let .secondary(isDisabled):
 			content
-				.foregroundColor(colorScheme == .light ? .black : .black)
+				.foregroundColor(disabledLabelColorBuilder(isDisabled))
 				.padding(.horizontal, 20)
 				.padding(.vertical, 10)
 				.frame(minWidth: 80)
@@ -45,6 +45,14 @@ struct GSLabelModifier: ViewModifier {
 				.frame(maxHeight: maxHeight)
 		}
 	}
+    
+    private func disabledLabelColorBuilder(_ isDisabled: Bool) -> Color {
+        if colorScheme == .light && isDisabled { return .white }
+        else if colorScheme == .light && !isDisabled { return .black }
+        else if colorScheme == .dark && isDisabled { return . white }
+        else if colorScheme == .dark && !isDisabled { return .black }
+        return .black
+    }
 	
     private func tertiaryForegroundColorBuilder(
         isAppliedInView: Bool?,

--- a/GitSpace/Utilities/ViewHighlightColorStyle.swift
+++ b/GitSpace/Utilities/ViewHighlightColorStyle.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+// TODO: DEPRECATE
 struct ViewHighlightColorStyle: ButtonStyle {
 	let style: Constant.LabelHierarchy
 	@Environment(\.colorScheme) var colorScheme


### PR DESCRIPTION
# MyPullRequest

## 개요 및 관련 이슈

- #65

## 작업 사항

1. `GSButton`의 `isDisabled`가 제대로 동작하지 않던 이슈를 해결합니다.
    - 버튼이 `isDisabled` 연관값을 제대로 받아오도록 코드 수정
    - label과 button 이 각각 `isDisabled`에 따라 적절한 UI를 display
    - 버튼이 `disabled()` 될 때, `systemGray`로 disable 되지 않도록 .overlay 활용
2. `GSNavigationLink`의 Second 스타일과 `GSButton`의 Second 스타일 불일치 이슈를 해결합니다.
    - 기존 `GSNavigationLink`가 갖고 있던 ViewHighlightColorStyle modifier를 `GSButton`에서 활용하는 modifier로 변경 및 수정
    - `GSNavigationLink`에 tapped Color, Capsule Button Style 적용

| GSButton, GSNavigation | GSButton, GSNavigation | GIFS |
| :--------: | :--------: | :--------: |
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-05-07 at 17 25 13](https://user-images.githubusercontent.com/82270058/236666452-58ccb031-3917-4a9f-8b72-e3e89974ac52.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-05-07 at 17 24 18](https://user-images.githubusercontent.com/82270058/236666428-7a3b3174-4e09-4584-af58-9cbc3c09ab3c.png) | ![Simulator Screen Recording - iPhone 14 Pro - 2023-05-07 at 17 14 36](https://user-images.githubusercontent.com/82270058/236666401-a35aadfb-29b0-4409-adf7-a8d5a68550b2.gif) |

## 주요 로직
```Swift
// 버튼이 `disabled()` 될 때, `systemGray`로 disable 되지 않도록 .overlay 활용
.overlay {
    // Custom Disable 구현을 위해 .disabled() 대신 Capsule을 overlay
    // why: .disabled()가 systemGray를 자동으로 적용하는 이슈
    if isDisabled {
        Capsule()
            .fill(.white.opacity(0.0001))
    }
}
```
