### PR TITLE
[Chore] BlockedUsers Class의 위치를 변경하고, BlockedUserList의 중복검사, 로그아웃/회원탈퇴 시 목록 비우기를 진행했습니다.

### DIFF
--- a/GitSpace.xcodeproj/project.pbxproj
+++ b/GitSpace.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		348540F7299D5F8600B738F9 /* AfterReportGuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348540F6299D5F8600B738F9 /* AfterReportGuideView.swift */; };
 		348540F9299DDC5500B738F9 /* TermsOfServiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348540F8299DDC5500B738F9 /* TermsOfServiceView.swift */; };
 		348AB2B829ACE5C200F2D465 /* ContributorListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348AB2B729ACE5C200F2D465 /* ContributorListCell.swift */; };
+		34991B292A07F17C0034297A /* BlockedUsers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34991B282A07F17C0034297A /* BlockedUsers.swift */; };
 		34BF6A6629C8ABBE00D15DFE /* TargetUserFollowingListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BF6A6529C8ABBE00D15DFE /* TargetUserFollowingListView.swift */; };
 		34BF6A6829C9F04700D15DFE /* FollowingResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BF6A6729C9F04700D15DFE /* FollowingResponse.swift */; };
 		34BF6A6A29CA0A4600D15DFE /* FollowingSkeletonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BF6A6929CA0A4600D15DFE /* FollowingSkeletonView.swift */; };
@@ -262,6 +263,7 @@
 		348540F6299D5F8600B738F9 /* AfterReportGuideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AfterReportGuideView.swift; sourceTree = "<group>"; };
 		348540F8299DDC5500B738F9 /* TermsOfServiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsOfServiceView.swift; sourceTree = "<group>"; };
 		348AB2B729ACE5C200F2D465 /* ContributorListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContributorListCell.swift; sourceTree = "<group>"; };
+		34991B282A07F17C0034297A /* BlockedUsers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedUsers.swift; sourceTree = "<group>"; };
 		34BC356E29779201000DCBC7 /* EachKnockCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EachKnockCell.swift; sourceTree = "<group>"; };
 		34BC357D2988EA4D000DCBC7 /* SendKnockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendKnockView.swift; sourceTree = "<group>"; };
 		34BF6A6529C8ABBE00D15DFE /* TargetUserFollowingListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetUserFollowingListView.swift; sourceTree = "<group>"; };
@@ -763,6 +765,7 @@
 				6E0840262983BB9A00F51169 /* UserInfo.swift */,
 				687AE54F298FA22500113ABF /* Repository.swift */,
 				687AE551298FA23700113ABF /* Tag.swift */,
+				34991B282A07F17C0034297A /* BlockedUsers.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1064,6 +1067,7 @@
 				22958CAD29C752B000786357 /* ReadmeLoadingView.swift in Sources */,
 				68C3CE6929F7C39900C8D1FC /* BlockView.swift in Sources */,
 				704D160F29992FF9009206BD /* String+.swift in Sources */,
+				34991B292A07F17C0034297A /* BlockedUsers.swift in Sources */,
 				6E128D6529A3BDFF0004AEC8 /* ImageCacheManager.swift in Sources */,
 				3476476229F160B400CCBD12 /* BlockedUsersListView.swift in Sources */,
 				6E70333E29890ADE00FFC018 /* ChatListSection.swift in Sources */,

--- a/GitSpace/Sources/Models/BlockedUsers.swift
+++ b/GitSpace/Sources/Models/BlockedUsers.swift
@@ -1,0 +1,11 @@
+//
+//  BlockedUsers.swift
+//  GitSpace
+//
+//  Created by 최한호 on 2023/05/07.
+//
+import Foundation
+
+final class BlockedUsers: ObservableObject {
+    
+}

--- a/GitSpace/Sources/Models/BlockedUsers.swift
+++ b/GitSpace/Sources/Models/BlockedUsers.swift
@@ -7,6 +7,10 @@
 import Foundation
 
 final class BlockedUsers: ObservableObject {
-    
+    /**
+     currentUser의 BlockedUsers를 담아줄 배열입니다. ContentView의 retrieveBlockedUserList 메서드를 통해 currentUser의 BlockedUsers를 blockedUserList에 담아줍니다.
+     - Properties: (UserInfo, GithubUser) 형식의 튜플 타입으로 이루어져 있습니다.
+     - Author: 한호
+     */
     @Published var blockedUserList: [(userInfo: UserInfo, gitHubUser: GithubUser)] = []
 }

--- a/GitSpace/Sources/Models/BlockedUsers.swift
+++ b/GitSpace/Sources/Models/BlockedUsers.swift
@@ -8,4 +8,5 @@ import Foundation
 
 final class BlockedUsers: ObservableObject {
     
+    @Published var blockedUserList: [(userInfo: UserInfo, gitHubUser: GithubUser)] = []
 }

--- a/GitSpace/Sources/Network/Interface/Blockable.swift
+++ b/GitSpace/Sources/Network/Interface/Blockable.swift
@@ -137,7 +137,3 @@ enum BlockError: Error {
     case blockCreateFailed
     case unblockDeleteFailed
 }
-
-class BlockedUsers: ObservableObject {
-    @Published var blockedUserList: [(userInfo: UserInfo, gitHubUser: GithubUser)] = []
-}

--- a/GitSpace/Sources/Views/Common/BlockView.swift
+++ b/GitSpace/Sources/Views/Common/BlockView.swift
@@ -67,8 +67,16 @@ struct BlockView: View, Blockable {
                         }
                         
                         let targetGitHubUser = assignGitHubUser(to: targetUser)
-                        blockedUsers.blockedUserList.append((targetUser, targetGitHubUser))
-                        
+
+                        if !blockedUsers.blockedUserList
+                            .contains(
+                                where: {
+                                    $0.0 == targetUser &&
+                                    $0.1 == targetGitHubUser
+                                }) {
+                            blockedUsers.blockedUserList
+                                .append((targetUser, targetGitHubUser))
+                        }
                     } label: {
                         Text("Yes")
                             .foregroundColor(.white)

--- a/GitSpace/Sources/Views/Common/BlockView.swift
+++ b/GitSpace/Sources/Views/Common/BlockView.swift
@@ -71,8 +71,8 @@ struct BlockView: View, Blockable {
                         if !blockedUsers.blockedUserList
                             .contains(
                                 where: {
-                                    $0.0 == targetUser &&
-                                    $0.1 == targetGitHubUser
+                                    $0.userInfo == targetUser &&
+                                    $0.gitHubUser == targetGitHubUser
                                 }) {
                             blockedUsers.blockedUserList
                                 .append((targetUser, targetGitHubUser))

--- a/GitSpace/Sources/Views/Settings/Account/SetAccountView.swift
+++ b/GitSpace/Sources/Views/Settings/Account/SetAccountView.swift
@@ -71,6 +71,7 @@ struct SetAccountView: View {
         .navigationBarTitle("Account", displayMode: .inline)
         .alert("Sign out", isPresented: $showingLogoutAlert) {
               Button("Sign out", role: .destructive) {
+                  blockedUsers.blockedUserList.removeAll()
                   gitHubAuthManager.signOut()
               }
         } message: {
@@ -79,6 +80,7 @@ struct SetAccountView: View {
         .alert("Delete Account", isPresented: $showingDeleteAccountAlert) {
               Button("Delete", role: .destructive) {
                   Task {
+                      blockedUsers.blockedUserList.removeAll()
                       await gitHubAuthManager.deleteCurrentUser()
                       await gitHubAuthManager.withdrawal()
                       reset()


### PR DESCRIPTION
## 개요 및 관련 이슈
- BlockedUsers Class의 위치를 변경했습니다.
- 중복 검사 후에 BlockedUserList에 값을 추가하도록 했습니다.
- 로그아웃 / 회원탈퇴 시 BlockedUserList를 비우게 했습니다.
- #412 

## 📋 작업 사항
### 1. BlockedUsers Class의 위치를 변경했습니다.
- `BlockedUsers.swift` 파일을 추가했습니다.
- `BlockedUsers` Class의 위치를 변경했습니다.
  - 전: `Blockable.swift`
  - 후: `BlockedUsers.swift`
- `BlockedUsers` Class에 주석을 추가했습니다.

### 2. 중복 검사 후에 BlockedUserList에 값을 추가하도록 했습니다.
- 현재 차단한 유저를 다시 차단할 수 없지만,
만일을 위해 중복검사를 통해 중복된 값이 추가되지 않도록 합니다.
- **주요 로직**
  ```swift
  //  BlockView.swift
  if !blockedUsers.blockedUserList.contains(
      where: {
          $0.0 == targetUser &&
          $0.1 == targetGitHubUser
      }) {
      blockedUsers.blockedUserList.append((targetUser, targetGitHubUser))
  }
  ```

### 3. 로그아웃 / 회원탈퇴 시 BlockedUserList를 비웁니다.
- **주요 로직**
  ```diff
  //  SetAccountView.swift
  //  #72 line 
  .alert("Sign out", isPresented: $showingLogoutAlert) {
      Button("Sign out", role: .destructive) {
  +       blockedUsers.blockedUserList.removeAll()
          gitHubAuthManager.signOut()
      }
  }
  
  //  #80 line
  .alert("Delete Account", isPresented: $showingDeleteAccountAlert) {
      Button("Delete", role: .destructive) {
          Task {
  +           blockedUsers.blockedUserList.removeAll()
              await gitHubAuthManager.deleteCurrentUser()
              await gitHubAuthManager.withdrawal()
              reset()
          }
      }
  }
  ```

## ✅ 확인한 사항
- `BlockedUsers` Class의 위치 변경 및 중복 검사 추가 후,
  - [x] 차단 로직이 잘 작동하는 지 확인했습니다.
  - [x] 차단 목록에 유저가 잘 보여지는 지 확인했습니다.
- [x] 차단 후, 다시 차단할 수 있는 지 확인했습니다.