### PR TITLE
[Fix] #396 신고한 유저가 이미 차단한 유저일 경우, 차단제안뷰가 나오지 않도록 수정했습니다.

### DIFF
--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -120,8 +120,6 @@ struct ChatRoomView: View, Blockable {
                 isSuggestBlockViewShowing: $showingSuggestBlockView,
                 targetUser: targetUserInfo
             )
-            .environmentObject(userStore)
-            .environmentObject(blockedUsers)
         }
         .halfSheet(isPresented: $showingSuggestBlockView) {
             SuggestBlockView(

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -27,6 +27,7 @@ struct ChatRoomView: View, Blockable {
     @EnvironmentObject private var messageStore: MessageStore
     @EnvironmentObject private var userStore: UserStore
     @EnvironmentObject private var pushNotificationManager: PushNotificationManager
+    @EnvironmentObject var blockedUsers: BlockedUsers
     @State private var contentField: String = ""
     @State private var unreadMessageIndex: Int?
     @State private var preMessageIDs: [String] = []

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -114,11 +114,14 @@ struct ChatRoomView: View, Blockable {
             }
              */
         }
-        .halfSheet(isPresented: $showingReportView) {
+        .sheet(isPresented: $showingReportView) {
             ReportView(
                 isReportViewShowing: $showingReportView,
-                isSuggestBlockViewShowing: $showingSuggestBlockView
+                isSuggestBlockViewShowing: $showingSuggestBlockView,
+                targetUser: targetUserInfo
             )
+            .environmentObject(userStore)
+            .environmentObject(blockedUsers)
         }
         .halfSheet(isPresented: $showingSuggestBlockView) {
             SuggestBlockView(

--- a/GitSpace/Sources/Views/Common/ReportView.swift
+++ b/GitSpace/Sources/Views/Common/ReportView.swift
@@ -128,11 +128,13 @@ Gitspace operation team will check and help you.
             ) {
                 /* report method call */
                 
-                /* report view dismiss -> suggest block view appear*/
+                /* report view dismiss -> suggest block view appear */
                 dismiss()
                 isReportViewShowing = false
                 if !isBlocked {
-                    isSuggestBlockViewShowing = true
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { /// animation이 끝나는데 시간이 걸리기 때문에, true로 바꾸는 코드를 조금 늦춘다. 그렇지 않으면 모달이 띄워지는데 충돌이 일어난다.
+                        isSuggestBlockViewShowing = true
+                    }
                 }
             } label: {
                 Text("Submit Report")

--- a/GitSpace/Sources/Views/Common/ReportView.swift
+++ b/GitSpace/Sources/Views/Common/ReportView.swift
@@ -145,8 +145,10 @@ Gitspace operation team will check and help you.
     }
 }
 
-struct ReportView_Previews: PreviewProvider {
-    static var previews: some View {
-        ReportView(isReportViewShowing: .constant(true), isSuggestBlockViewShowing: .constant(false), isBlocked: .constant(false))
-    }
-}
+extension ReportView: Blockable { }
+
+//struct ReportView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        ReportView(isReportViewShowing: .constant(true), isSuggestBlockViewShowing: .constant(false))
+//    }
+//}

--- a/GitSpace/Sources/Views/Common/ReportView.swift
+++ b/GitSpace/Sources/Views/Common/ReportView.swift
@@ -11,6 +11,7 @@ struct ReportView: View {
     @Environment(\.dismiss) private var dismiss
     @Binding var isReportViewShowing: Bool
     @Binding var isSuggestBlockViewShowing: Bool
+    @Binding var isBlocked: Bool
     
     @State private var reportReason: String?
     @State private var reportReasonNumber: Int?
@@ -122,7 +123,9 @@ Gitspace operation team will check and help you.
                 /* report view dismiss -> suggest block view appear*/
                 dismiss()
                 isReportViewShowing = false
-                isSuggestBlockViewShowing = true
+                if !isBlocked {
+                    isSuggestBlockViewShowing = true
+                }
             } label: {
                 Text("Submit Report")
             }
@@ -134,6 +137,6 @@ Gitspace operation team will check and help you.
 
 struct ReportView_Previews: PreviewProvider {
     static var previews: some View {
-        ReportView(isReportViewShowing: .constant(true), isSuggestBlockViewShowing: .constant(false))
+        ReportView(isReportViewShowing: .constant(true), isSuggestBlockViewShowing: .constant(false), isBlocked: .constant(false))
     }
 }

--- a/GitSpace/Sources/Views/Common/ReportView.swift
+++ b/GitSpace/Sources/Views/Common/ReportView.swift
@@ -9,6 +9,9 @@ import SwiftUI
 
 struct ReportView: View {
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject var userInfoManager: UserStore
+    @EnvironmentObject var blockedUsers: BlockedUsers
+    
     @Binding var isReportViewShowing: Bool
     @Binding var isSuggestBlockViewShowing: Bool
     @Binding var isBlocked: Bool

--- a/GitSpace/Sources/Views/Common/ReportView.swift
+++ b/GitSpace/Sources/Views/Common/ReportView.swift
@@ -18,6 +18,8 @@ struct ReportView: View {
     @State private var reportReason: String?
     @State private var reportReasonNumber: Int?
     
+    var targetUser: UserInfo
+    
     var isReportReasonSelected: Bool {
         guard reportReasonNumber != nil else {
             return false

--- a/GitSpace/Sources/Views/Common/ReportView.swift
+++ b/GitSpace/Sources/Views/Common/ReportView.swift
@@ -28,7 +28,9 @@ struct ReportView: View {
     }
     
     var isBlocked: Bool {
-        blockedUsers.blockedUserList.contains(where: { $0.userInfo.id == targetUser.id })
+        blockedUsers.blockedUserList.contains{
+            $0.userInfo.id == targetUser.id
+        }
     }
         
     var body: some View {

--- a/GitSpace/Sources/Views/Common/ReportView.swift
+++ b/GitSpace/Sources/Views/Common/ReportView.swift
@@ -14,7 +14,6 @@ struct ReportView: View {
     
     @Binding var isReportViewShowing: Bool
     @Binding var isSuggestBlockViewShowing: Bool
-    @Binding var isBlocked: Bool
     
     @State private var reportReason: String?
     @State private var reportReasonNumber: Int?
@@ -24,6 +23,10 @@ struct ReportView: View {
             return false
         }
         return true
+    }
+    
+    var isBlocked: Bool {
+        blockedUsers.blockedUserList.contains(where: { $0.userInfo.id == targetUser.id })
     }
         
     var body: some View {

--- a/GitSpace/Sources/Views/Home/RepositoryDetailView.swift
+++ b/GitSpace/Sources/Views/Home/RepositoryDetailView.swift
@@ -231,7 +231,6 @@ struct RepositoryDetailViewTags: View {
         .onAppear {
             Task {
                 selectedTags = await tagViewModel.requestRepositoryTags(repositoryName: repository.fullName) ?? []
-                let _ = print("++++", selectedTags)
             }
         }
     }

--- a/GitSpace/Sources/Views/Knock/MainKnockBox/KnockHistoryView.swift
+++ b/GitSpace/Sources/Views/Knock/MainKnockBox/KnockHistoryView.swift
@@ -301,11 +301,16 @@ struct KnockHistoryView: View {
             }
             .padding(.horizontal, 20)
         }
-        .halfSheet(isPresented: $isReporting) {
-            ReportView(
-                isReportViewShowing: $isReporting,
-                isSuggestBlockViewShowing: $isBlocking
-            )
+        .sheet(isPresented: $isReporting) {
+            if let targetUser = targetUserInfo {
+                ReportView(
+                    isReportViewShowing: $isReporting,
+                    isSuggestBlockViewShowing: $isBlocking,
+                    targetUser: targetUser
+                )
+                .environmentObject(userInfoManager)
+                .environmentObject(blockedUsers)
+            }
         }
         .onTapGesture {
             self.endTextEditing()

--- a/GitSpace/Sources/Views/Knock/MainKnockBox/KnockHistoryView.swift
+++ b/GitSpace/Sources/Views/Knock/MainKnockBox/KnockHistoryView.swift
@@ -308,8 +308,6 @@ struct KnockHistoryView: View {
                     isSuggestBlockViewShowing: $isBlocking,
                     targetUser: targetUser
                 )
-                .environmentObject(userInfoManager)
-                .environmentObject(blockedUsers)
             }
         }
         .onTapGesture {

--- a/GitSpace/Sources/Views/Knock/MainKnockBox/KnockHistoryView.swift
+++ b/GitSpace/Sources/Views/Knock/MainKnockBox/KnockHistoryView.swift
@@ -14,6 +14,7 @@ struct KnockHistoryView: View {
     @EnvironmentObject var tabBarRouter: GSTabBarRouter
     @EnvironmentObject var userInfoManager: UserStore
     @EnvironmentObject var chatStore: ChatStore
+    @EnvironmentObject var blockedUsers: BlockedUsers
     
     @State private var targetUserInfo: UserInfo? = nil
     @State private var isReporting: Bool = false

--- a/GitSpace/Sources/Views/Knock/MainKnockBox/ReceivedKnockDetailView.swift
+++ b/GitSpace/Sources/Views/Knock/MainKnockBox/ReceivedKnockDetailView.swift
@@ -209,10 +209,15 @@ struct ReceivedKnockDetailView: View {
             }
         }
         .sheet(isPresented: $isReporting) {
-            ReportView(
-                isReportViewShowing: $isReporting,
-                isSuggestBlockViewShowing: $isBlockOtherUser
-            )
+            if let targetUser {
+                ReportView(
+                    isReportViewShowing: $isReporting,
+                    isSuggestBlockViewShowing: $isBlockOtherUser,
+                    targetUser: targetUser
+                )
+                .environmentObject(userStore)
+                .environmentObject(blockedUsers)
+            }
         }
         .task {
             self.targetUser = await userStore.requestUserInfoWithID(userID: knock.sentUserID)

--- a/GitSpace/Sources/Views/Knock/MainKnockBox/ReceivedKnockDetailView.swift
+++ b/GitSpace/Sources/Views/Knock/MainKnockBox/ReceivedKnockDetailView.swift
@@ -215,8 +215,6 @@ struct ReceivedKnockDetailView: View {
                     isSuggestBlockViewShowing: $isBlockOtherUser,
                     targetUser: targetUser
                 )
-                .environmentObject(userStore)
-                .environmentObject(blockedUsers)
             }
         }
         .task {

--- a/GitSpace/Sources/Views/Knock/MainKnockBox/ReceivedKnockDetailView.swift
+++ b/GitSpace/Sources/Views/Knock/MainKnockBox/ReceivedKnockDetailView.swift
@@ -15,6 +15,7 @@ struct ReceivedKnockDetailView: View {
     @EnvironmentObject var userStore: UserStore
     @EnvironmentObject var chatStore: ChatStore
     @EnvironmentObject var tabBarRouter: GSTabBarRouter
+    @EnvironmentObject var blockedUsers: BlockedUsers
     
     @Binding var knock: Knock
     @State private var isAccepted: Bool = false

--- a/GitSpace/Sources/Views/Knock/SendKnockView.swift
+++ b/GitSpace/Sources/Views/Knock/SendKnockView.swift
@@ -281,7 +281,7 @@ Please write a message carefully.
                             // FIXME: 노크 전송 버튼 disabled 조건에 isKnockSent 추가 필요함! From. 영이 -> To. 노이
                             if
                                 let currentUser = userStore.currentUser,
-                                let targetUserInfo,
+//                                let targetUserInfo,
                                 !isKnockSent {
                                 GSTextEditor.CustomTextEditorView(
                                     style: .message,
@@ -382,7 +382,7 @@ Please write a message carefully.
                             
                             if
                                 let currentUser = userStore.currentUser,
-                                let targetUserInfo,
+//                                let targetUserInfo,
                                !isKnockSent {
                                 GSTextEditor.CustomTextEditorView(
                                     style: .message,

--- a/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
+++ b/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
@@ -336,8 +336,6 @@ struct TargetUserProfileView: View {
                     isSuggestBlockViewShowing: $isSuggestBlockViewShowing,
                     targetUser: targetUser
                 )
-                .environmentObject(userInfoManager)
-                .environmentObject(blockedUsers)
             }
         }
         .halfSheet(isPresented: $isSuggestBlockViewShowing) {

--- a/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
+++ b/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
@@ -329,11 +329,16 @@ struct TargetUserProfileView: View {
                 .environmentObject(blockedUsers)
             }
         }
-        .halfSheet(isPresented: $isReportViewShowing) {
-            ReportView(
-                isReportViewShowing: $isReportViewShowing,
-                isSuggestBlockViewShowing: $isSuggestBlockViewShowing
-            )
+        .sheet(isPresented: $isReportViewShowing) {
+            if let targetUser = targetUserInfo {
+                ReportView(
+                    isReportViewShowing: $isReportViewShowing,
+                    isSuggestBlockViewShowing: $isSuggestBlockViewShowing,
+                    targetUser: targetUser
+                )
+                .environmentObject(userInfoManager)
+                .environmentObject(blockedUsers)
+            }
         }
         .halfSheet(isPresented: $isSuggestBlockViewShowing) {
             SuggestBlockView(

--- a/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
+++ b/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
@@ -320,16 +320,26 @@ struct TargetUserProfileView: View {
         }
         .halfSheet(isPresented: $isBlockViewShowing) {
             if let targetUserInfo {
-                BlockView(isBlockViewShowing: $isBlockViewShowing, isBlockedUser: $isBlockedUser, targetUser: targetUserInfo)
-                    .environmentObject(userInfoManager)
-                    .environmentObject(blockedUsers)
+                BlockView(
+                    isBlockViewShowing: $isBlockViewShowing,
+                    isBlockedUser: $isBlockedUser,
+                    targetUser: targetUserInfo
+                )
+                .environmentObject(userInfoManager)
+                .environmentObject(blockedUsers)
             }
         }
         .halfSheet(isPresented: $isReportViewShowing) {
-            ReportView(isReportViewShowing: $isReportViewShowing, isSuggestBlockViewShowing: $isSuggestBlockViewShowing)
+            ReportView(
+                isReportViewShowing: $isReportViewShowing,
+                isSuggestBlockViewShowing: $isSuggestBlockViewShowing
+            )
         }
         .halfSheet(isPresented: $isSuggestBlockViewShowing) {
-            SuggestBlockView(isBlockViewShowing: $isBlockViewShowing, isSuggestBlockViewShowing: $isSuggestBlockViewShowing)
+            SuggestBlockView(
+                isBlockViewShowing: $isBlockViewShowing,
+                isSuggestBlockViewShowing: $isSuggestBlockViewShowing
+            )
         }
         .toolbar {
             if (isGitSpaceUser && userInfoManager.currentUser?.githubID != user.id) {


### PR DESCRIPTION
## 개요 및 관련 이슈
- 신고한 유저가 이미 차단한 유저일 경우, 차단제안뷰(SuggestBlockView)가 나오지 않도록 수정했습니다.
- #396 

<br>

## 📋 작업 사항
### 1. 차단유저 확인을 위하여 ReportView에 `blockedUser`, `isBlocked`, `targetUser` 프로퍼티 추가
```swift
struct ReportView: View { 
    @EnvironmentObject var blockedUsers: BlockedUsers

    var targetUser: UserInfo

    var isBlocked: Bool {
        blockedUsers.blockedUserList.contains(where: { $0.userInfo.id == targetUser.id })
    }
    ...
}
```
* `blockedUser`
    * 현재 사용자가 차단한 유저의 목록을 사용하기 위해 BlockedUsers의 전역 객체를 사용합니다.
* `targetUser`
   * ReportView에서 차단할 사용자입니다.
* `isBlocked`
   * 현재 사용자가 차단한 유저의 목록에서 targetUser(차단한 유저)가 있는지 확인한 결과를 가지고 있습니다.

<br>

### 2. ReportView, SuggestBlockView를 sheet로 사용하고 있는 4개의 뷰에 코드 추가
- `TargetUserProfileView`
- `ChatRoomVIew`
- `ReceivedKnockDetailView`
- `KnockHistoryView`
```diff
.sheet(isPresented: $isReportViewShowing) {
+ if let targetUser = targetUserInfo {
      ReportView(
          isReportViewShowing: $isReportViewShowing,
          isSuggestBlockViewShowing: $isSuggestBlockViewShowing,
+         targetUser: targetUser
      )
  }
}
```
<br>

## ✅ 확인한 사항
* [x] `TargetUserProfileView`에서 SuggestBlockView가 분기 처리되는지 확인했습니다.

<br>

## 📝 확인해야 할 사항
> Chat과 Knock가 없는 관계로 회의 중에 확인이 필요합니다.
* [ ] `ChatRoomView`에서 SuggestBlockView가 분기 처리되는지 확인합니다.
* [ ] `ReceivedKnockDetailView`에서 SuggestBlockView가 분기 처리되는지 확인합니다.
* [ ] `KnockHistoryView`에서 SuggestBlockView가 분기 처리되는지 확인합니다.

<br>

## 🐛 작업 중 발견한 버그
* TargetUserProfileView에서 @ValseLee 님을 차단해도 블락 유저로 걸리지 않는 현상
  * 다른 유저는 정상적으로 블락 유저가 확인되는데 승준님 계정만 블락 유저 확인이 안됩니다.
  * 승준님을 차단하고 프로필뷰를 나갔다가 다시 승준님 프로필로 들어가면 블락이 되었는지 알려주는 상단의 텍스트가 뜨지 않습니다.
  * 로직 문제보다는 DB에서 과거 계정 데이터와 꼬인 것으로 추측됩니다.
