### PR TITLE
[Fix] 신고/차단 Sheet 호출 방식을 사용하기 쉽도록 통합했습니다.

### DIFF
--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -113,6 +113,14 @@ struct ChatRoomView: View, Blockable {
             }
              */
         }
+        .reportCombineSheet(
+            reportViewIsPresented: $showingReportView,
+            suggestViewIsPresented: $showingSuggestBlockView,
+            blockViewIsPresented: $showingBlockView,
+            isBlockedUser: $isBlockedUser,
+            targetUserInfo: targetUserInfo
+        )
+        /*
         .halfSheet(isPresented: $showingReportView) {
             ReportView(
                 isReportViewShowing: $showingReportView,
@@ -132,6 +140,7 @@ struct ChatRoomView: View, Blockable {
                 targetUser: targetUserInfo
             )
         }
+         */
         .onDisappear {
             // 초기화 필요.
             pushNotificationManager.currentChatRoomID = nil

--- a/GitSpace/Utilities/Extensions/View+.swift
+++ b/GitSpace/Utilities/Extensions/View+.swift
@@ -67,4 +67,32 @@ extension View {
                  )
             }
     }
+    
+    func reportCombineSheet(
+        reportViewIsPresented: Binding<Bool>,
+        suggestViewIsPresented: Binding<Bool>,
+        blockViewIsPresented: Binding<Bool>,
+        isBlockedUser: Binding<Bool>,
+        targetUserInfo: UserInfo
+    ) -> some View {
+        self
+            .sheet(isPresented: reportViewIsPresented) {
+                ReportView(
+                    isReportViewShowing: reportViewIsPresented,
+                    isSuggestBlockViewShowing: suggestViewIsPresented
+                )
+            }
+            .sheet(isPresented: suggestViewIsPresented) {
+                SuggestBlockView(
+                    isBlockViewShowing: blockViewIsPresented,
+                    isSuggestBlockViewShowing: suggestViewIsPresented
+                )
+            }
+            .sheet(isPresented: blockViewIsPresented) {
+                BlockView(
+                    isBlockViewShowing: blockViewIsPresented,
+                    isBlockedUser: isBlockedUser,
+                    targetUser: targetUserInfo)
+            }
+    }
 }

--- a/GitSpace/Utilities/Extensions/View+.swift
+++ b/GitSpace/Utilities/Extensions/View+.swift
@@ -68,7 +68,7 @@ extension View {
             }
     }
     
-    func reportCombineSheet(
+    func reportBlockProcessSheet(
         reportViewIsPresented: Binding<Bool>,
         suggestViewIsPresented: Binding<Bool>,
         blockViewIsPresented: Binding<Bool>,


### PR DESCRIPTION
## 개요 및 관련 이슈
- Report-Suggest-Block sheet를 호출하기 쉽도록 reportCombineSheet로 통합했습니다.
- #417 

## 작업 사항

### View+ 익스텐션 메서드로 reportCombineSheet 추가

```swift
func reportCombineSheet(
    reportViewIsPresented: Binding<Bool>,
    suggestViewIsPresented: Binding<Bool>,
    blockViewIsPresented: Binding<Bool>,
    isBlockedUser: Binding<Bool>,
    targetUserInfo: UserInfo
) -> some View {
    self
        .sheet(isPresented: reportViewIsPresented) {
            ReportView(
                isReportViewShowing: reportViewIsPresented,
                isSuggestBlockViewShowing: suggestViewIsPresented
            )
        }
        .sheet(isPresented: suggestViewIsPresented) {
            SuggestBlockView(
                isBlockViewShowing: blockViewIsPresented,
                isSuggestBlockViewShowing: suggestViewIsPresented
            )
        }
        .sheet(isPresented: blockViewIsPresented) {
            BlockView(
                isBlockViewShowing: blockViewIsPresented,
                isBlockedUser: isBlockedUser,
                targetUser: targetUserInfo)
        }
}
```
## ✅ 확인한 사항
* [x] `ChatRoomView`에서 `reportCombineSheet`가 정상 작동하는 것을 확인했습니다.

![Simulator Screen Recording - iPhone 14 Pro Max - 2023-05-11 at 04 55 40](https://github.com/APPSCHOOL1-REPO/finalproject-gitspace/assets/45925685/2dfcfa68-18c6-4da2-9a98-38d93d82cef8)

<br>

## 📝 확인해야 할 사항
> 혼자서 결정하기 어려운 사항으로 의견이 필요합니다.
* [x] 이전에 halfSheet와 SwiftUI API Sheet의 비교에 관한 의견이 있어서 Sheet로 구현하였는데 적절한지 확인합니다.
* [x] Sheet를 유지할 경우 Report - Suggest - Block의 present 사이에 dismiss 동작이 필요할지 의견을 확인합니다.
* [x] #415 PR에서 `ReportView`에 targetUserInfo, isBlocked 프로퍼티가 추가되었는데 `BlockView`에서 해당 프로퍼티를 이니셜라이저에서 파라미터로 전달받고 있습니다. ReportView에서 받은 아규먼트를 재사용 가능한지 논의가 필요합니다. w. @dahae0320 




