### PR TITLE
[Fix] 신고, 차단 로직의 toggle 호출을 정리합니다

### DIFF
--- a/GitSpace/Sources/Views/Common/BlockView.swift
+++ b/GitSpace/Sources/Views/Common/BlockView.swift
@@ -58,7 +58,7 @@ struct BlockView: View, Blockable {
                     GSButton.CustomButtonView(style: .plainText(isDestructive: true)) {
                         /* Block Method Call */
                         isBlockViewShowing = false
-                        isBlockedUser.toggle()
+                        isBlockedUser = true
                         
                         Task {
                             if let currentUser = userInfoManager.currentUser {

--- a/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
+++ b/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
@@ -338,7 +338,7 @@ struct TargetUserProfileView: View {
                         if !blockedUsers.blockedUserList.contains(where: { $0.gitHubUser == user }) {
                             Button(role: .destructive, action: {
                                 /* Block 모달 뷰 appear */
-                                isBlockViewShowing.toggle()
+                                isBlockViewShowing = true
                             }) {
                                 Label("Block", systemImage: "nosign")
                             }
@@ -346,7 +346,7 @@ struct TargetUserProfileView: View {
                         
                         Button(role: .destructive, action: {
                             /* Report 모달 뷰 appear */
-                            isReportViewShowing.toggle()
+                            isReportViewShowing = true
                         }) {
                             Label("Report", systemImage: "exclamationmark.bubble")
                         }


### PR DESCRIPTION
## 개요 및 관련 이슈
- 신고, 차단 로직의 toggle 호출을 정리하였습니다.
- #416 

## 작업 사항
- 가독성을 높이고 오류 발생을 막기 위해 .toggle() 메서드가 아닌, Bool값을 직접 할당하였습니다.

## 발견한 사항
- 유저에 대한 차단을 해제했음에도 ChatRoom에 진입시 TextField가 막혀있는 문제가 간헐적으로 발생합니다.
- ChatRoom -> View Profile -> TargetUserProfileView -> 차단 -> 다시 ChatRoom 순서대로 이동시 유저를 차단했음에도 아직 TextField가 막혀있지 않는 현상이 발생합니다.
