### PR TITLE
[Fix] Repository에 tag를 등록하고 다시 태그추가뷰로 가면 deselect 되어있는 버그를 고쳤습니다.

### DIFF
--- a/GitSpace/Sources/ViewModels/TagViewModel.swift
+++ b/GitSpace/Sources/ViewModels/TagViewModel.swift
@@ -22,11 +22,11 @@ final class TagViewModel: ObservableObject {
     @MainActor
     func requestTags() async -> Void {
         do {
+            self.tags.removeAll()
             let snapshot = try await database.collection(const.COLLECTION_USER_INFO)
                 .document(Auth.auth().currentUser?.uid ?? "")
                 .collection(const.COLLECTION_TAG)
                 .getDocuments()
-            self.tags.removeAll()
             for document in snapshot.documents {
                 let id = document[const.FIELD_ID] as? String ?? ""
                 let tagName = document[const.FIELD_TAGNAME] as? String ?? ""

--- a/GitSpace/Sources/Views/Home/AddTagSheetView.swift
+++ b/GitSpace/Sources/Views/Home/AddTagSheetView.swift
@@ -17,11 +17,12 @@ struct AddTagSheetView: View {
     @Environment(\.dismiss) private var dismiss
     @EnvironmentObject var repositoryViewModel: RepositoryViewModel
     @EnvironmentObject var tagViewModel: TagViewModel
+    @StateObject private var keyboardHandler = KeyboardHandler()
     @Binding var preSelectedTags: [Tag]
     @State var selectedTags: [Tag]
     @State var deselectedTags: [Tag] = []
     @State private var tagInput: String = ""
-    @StateObject private var keyboardHandler = KeyboardHandler()
+    
     /// 어떤 뷰에서 AddTagSheetView를 호출했는지 확인합니다.
     var beforeView: BeforeView
     let selectedRepository: Repository?

--- a/GitSpace/Sources/Views/Home/AddTagSheetView.swift
+++ b/GitSpace/Sources/Views/Home/AddTagSheetView.swift
@@ -23,11 +23,10 @@ struct AddTagSheetView: View {
     @State var deselectedTags: [Tag] = []
     @State private var tagInput: String = ""
     
+    let selectedRepository: Repository?
+    let columns = [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())]
     /// 어떤 뷰에서 AddTagSheetView를 호출했는지 확인합니다.
     var beforeView: BeforeView
-    let selectedRepository: Repository?
-    
-    let columns = [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())]
     
     var trimmedTagInput: String {
         tagInput.trimmingCharacters(in: .whitespaces)

--- a/GitSpace/Sources/Views/Home/AddTagSheetView.swift
+++ b/GitSpace/Sources/Views/Home/AddTagSheetView.swift
@@ -36,9 +36,9 @@ struct AddTagSheetView: View {
         trimmedTagInput != ""
     }
     
+    /// tagList에 이미 존재하는 이름의 태그가 있다면 필터에서 걸리게 된다.
+    /// 그러므로 배열에 값이 존재하므로, isEmpty값이 true가 되고 Tag가 존재함을 알 수 있다.
     var shouldExistTag: Bool {
-        /// tagList에 이미 존재하는 이름의 태그가 있다면 필터에서 걸리게 된다.
-        /// 그러므로 배열에 값이 존재하므로, isEmpty값이 true가 되고 Tag가 존재함을 알 수 있다.
         return tagViewModel.tags.filter { tag in
             tag.tagName == trimmedTagInput
         }.isEmpty

--- a/GitSpace/Sources/Views/Home/AddTagSheetView.swift
+++ b/GitSpace/Sources/Views/Home/AddTagSheetView.swift
@@ -65,7 +65,7 @@ struct AddTagSheetView: View {
     /// 태그를 선택할 경우 발생하는 로직을 수행하는 메서드입니다.
     /// 선택되지 않은 태그를 선택할 경우와 이미 선택된 태그를 선택할 경우로 분기처리된다.
     func selectTag(to tag: Tag) {
-        if selectedTags.contains(tag) {
+        if selectedTags.contains(where: { $0.id == tag.id }) {
             deselectedTags.append(tag)
             guard let selectedIndex: Int = selectedTags.firstIndex(of: tag) else {
                 return
@@ -180,7 +180,7 @@ struct AddTagSheetView: View {
                                 GSButton.CustomButtonView(
                                     style: .tag(
 //                                        isAppliedInView: selectedTags.contains(tag),
-                                        isSelectedInAddTagSheet: selectedTags.contains(tag)
+                                        isSelectedInAddTagSheet: selectedTags.contains{ $0.id == tag.id }
                                     )
                                 ) {
                                     withAnimation {

--- a/GitSpace/Sources/Views/Home/AddTagSheetView.swift
+++ b/GitSpace/Sources/Views/Home/AddTagSheetView.swift
@@ -67,13 +67,13 @@ struct AddTagSheetView: View {
     func selectTag(to tag: Tag) {
         if selectedTags.contains(where: { $0.id == tag.id }) {
             deselectedTags.append(tag)
-            guard let selectedIndex: Int = selectedTags.firstIndex(of: tag) else {
+            guard let selectedIndex: Int = selectedTags.firstIndex(where: { $0.id == tag.id }) else {
                 return
             }
             selectedTags.remove(at: selectedIndex)
         } else {
             selectedTags.append(tag)
-            guard let deselectedIndex: Int = deselectedTags.firstIndex(of: tag) else {
+            guard let deselectedIndex: Int = deselectedTags.firstIndex(where: { $0.id == tag.id }) else {
                 return
             }
             deselectedTags.remove(at: deselectedIndex)

--- a/GitSpace/Sources/Views/Home/AddTagSheetView.swift
+++ b/GitSpace/Sources/Views/Home/AddTagSheetView.swift
@@ -106,10 +106,10 @@ struct AddTagSheetView: View {
                 }
             }
         case .starredView:
-            if !selectedTags.isEmpty {
-                repositoryViewModel.filterRepository(selectedTagList: preSelectedTags)
-            } else {
+            if selectedTags.isEmpty {
                 repositoryViewModel.filteredRepositories = repositoryViewModel.repositories
+            } else {
+                repositoryViewModel.filterRepository(selectedTagList: preSelectedTags)
             }
         }
     }
@@ -135,7 +135,7 @@ struct AddTagSheetView: View {
                             .onSubmit {
                                 addNewTag()
                             }
-                            // 태그 추가 버튼
+                            
                             Button {
                                 // FIXME: Animation이 너무 못생겼음.
                                 /// 앞에서 추가되면 자연스럽게 밀리는 애니메이션으로 수정하기.
@@ -168,7 +168,10 @@ struct AddTagSheetView: View {
                         } else {
                             GSText.CustomTextView(
                                 style: .caption1,
-                                string: beforeView == .starredView ? "Select tags from your tag list 🙌" : "Select tags from your repository tag list 🙌")
+                                string: beforeView == .starredView
+                                ? "Select tags from your tag list 🙌"
+                                : "Select tags from your repository tag list 🙌"
+                            )
 
                             /// selectedTag에 있는 태그만 미리 선택된 채로 있어야 한다.
                             FlowLayout(

--- a/GitSpace/Sources/Views/Home/RepositoryDetailView.swift
+++ b/GitSpace/Sources/Views/Home/RepositoryDetailView.swift
@@ -226,7 +226,12 @@ struct RepositoryDetailViewTags: View {
         // FIXME: selectedTag의 값
         /// 실제로는 각 레포가 가지고 있는 태그가 들어와야 한다!
         .fullScreenCover(isPresented: $isTagSheetShowed) {
-            AddTagSheetView(preSelectedTags: $selectedTags, selectedTags: selectedTags, beforeView: .repositoryDetailView, selectedRepository: repository)
+            AddTagSheetView(
+                preSelectedTags: $selectedTags,
+                selectedTags: selectedTags,
+                selectedRepository: repository,
+                beforeView: .repositoryDetailView
+            )
         }
         .onAppear {
             Task {

--- a/GitSpace/Sources/Views/Home/RepositoryDetailView.swift
+++ b/GitSpace/Sources/Views/Home/RepositoryDetailView.swift
@@ -77,7 +77,6 @@ struct RepositoryDetailView: View {
                 .padding(.horizontal, 20)
             }
         }
-//        .padding(.horizontal, 30)
         .onViewDidLoad {
             Task {
                 let readMeResult = await repositoryDetailViewModel.requestReadMe(repository: repository)

--- a/GitSpace/Sources/Views/Home/StarredView.swift
+++ b/GitSpace/Sources/Views/Home/StarredView.swift
@@ -234,7 +234,12 @@ struct StarredView: View {
             }
         }
         .sheet(isPresented: $isShowingSelectTagView) {
-            AddTagSheetView(preSelectedTags: $selectedTagList, selectedTags: selectedTagList, beforeView: .starredView, selectedRepository: nil)
+            AddTagSheetView(
+                preSelectedTags: $selectedTagList,
+                selectedTags: selectedTagList,
+                selectedRepository: nil,
+                beforeView: .starredView
+            )
         }
         .onTapGesture {
             self.endTextEditing()


### PR DESCRIPTION
## 개요 및 관련 이슈
- Repository에 tag를 등록하고 다시 태그추가뷰로 가면 deselect 되어있는 버그를 고쳤습니다.
- #397 

## 📋 작업 사항
### 0. 버그 분석
#### 문제 상황
  1. Repository에 tag를 등록하고 다시 AddTagSheetView로 가면 방금 등록한 tag가 deselect 되어 있다. (select이 되어야 정상)
  2. 그 상태에서 해당 tag를 다시 등록하면 Repository에 같은 tag가 1개 더 들어간다. (DB에는 반영x, view에서 중복으로 표현)

#### 버그 시나리오
  1. RepositoryDetail에서 '+'버튼 눌러 AddTagSheetView로 이동
  2. AddTagSheetView에서 특정 Tag를 Selection 후 Done 버튼 탭
  3. AddTagSheetView dismiss
  4. RepositoryDetail Appear
  5. 다시 1번 - 4번 반복하면 RepositoryDetail의 My Tag에 같은 태그가 2번 들어간다.

#### 문제 원인
모든 tag를 보여주는 반복문에서 사용자가 만든 tag들(tagViewModel.tags)과 선택된 tag들(selectedTags)에서 겹치는 tag를 선택된 tag로 보여주고 있습니다.
작업 이전에는 겹치는 tag가 있는지 확인하는 로직에서 tag 객체를 기준으로 비교하고 있었습니다. 그래서 tag를 등록한 직후에는 해당 tag값에 repo 정보가 들어가 있지 않습니다. 

한마디로 " **이름과 id는 같지만 repo 정보가 채워져있지 않아서 같은 tag로 인식하지 못한 것** "이 원인입니다.

#### 해결 방법
단순하게 Firebase에서 tag 정보를 다시 받아올 수 있었지만, (1)request 요청이 늘어날 것과 (2)버그의 원인보다 더 큰 범위로 문제를 해결하는 것 같아서 해당 방식은 채택하지 않았습니다.

최종적으로 selectedTags에 있는 tag를 비교하는 로직들의 기준을 tag id로 바꿈으로서 버그를 고칠 수 있었습니다.

<br>

### 1. AddTagSheetView에서 selectedTags에 tag가 포함되었는지 확인하는 기준 변경
```diff
func selectTag(to tag: Tag) {
+   if selectedTags.contains(where: { $0.id == tag.id }) {
-   if selectedTags.contains(tag) {
        deselectedTags.append(tag)
+       guard let selectedIndex: Int = selectedTags.firstIndex(where: { $0.id == tag.id }) else {
-       guard let selectedIndex: Int = selectedTags.firstIndex(tag) else {
            return
        }
        selectedTags.remove(at: selectedIndex)
    } else {
        selectedTags.append(tag)
+       guard let deselectedIndex: Int = deselectedTags.firstIndex(where: { $0.id == tag.id }) else {
-       guard let deselectedIndex: Int = deselectedTags.firstIndex(tag) else {
            return
        }
        deselectedTags.remove(at: deselectedIndex)
    }
}
```
- 작업 전: Tag 타입을 가진 객체 전체로 포함 여부 확인
- 작업 후: Tag 타입을 가진 객체의 **고유 id 값**으로 포함 여부 확인

#### 참고사항
* contains와 firstIndex 메소드를 호출할 때 `where`을 생략하지 않고 작성한 이유
   * if문에서 컴파일러가 모호한 표현이라고 헷갈려함 (warning)
![image](https://github.com/APPSCHOOL1-REPO/finalproject-gitspace/assets/50159740/f3c7fc04-9f52-4652-a2c7-ec50c5802615)

   * guard문에서 `Anonymous closure argument not contained in a closure`라는 에러가 떠서 사용할 수 없음
![image](https://github.com/APPSCHOOL1-REPO/finalproject-gitspace/assets/50159740/4dc54216-d3bb-4257-afc9-1e0615df51aa)

혹시나 이 부분을 개선할 수 있다면 코멘트로 남겨주세요!

<br>

### 2. 코드 수정
- 필요없는 주석 제거
- 매개변수가 1개 이상인 호출부 줄바꿈 처리


