### PR TITLE
[Fix] GSTextEditor 구조를 리팩토링했습니다.

### DIFF
--- a/GitSpace.xcodeproj/project.pbxproj
+++ b/GitSpace.xcodeproj/project.pbxproj
@@ -128,6 +128,8 @@
 		6E0F9595298CF5F8000FE529 /* GSTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E0F9594298CF5F8000FE529 /* GSTextEditor.swift */; };
 		6E128D6529A3BDFF0004AEC8 /* ImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E128D6429A3BDFF0004AEC8 /* ImageCacheManager.swift */; };
 		6E128D6729A498A50004AEC8 /* Image+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E128D6629A498A50004AEC8 /* Image+.swift */; };
+		6E1FC6552A115ABD003A77CB /* Int+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1FC6542A115ABD003A77CB /* Int+.swift */; };
+		6E1FC6572A116833003A77CB /* CGFloat+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1FC6562A116833003A77CB /* CGFloat+.swift */; };
 		6E38C6042991EF380043A8BB /* ChatListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E38C6032991EF380043A8BB /* ChatListCell.swift */; };
 		6E38C6062991EF590043A8BB /* ChatListSkeletonCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E38C6052991EF590043A8BB /* ChatListSkeletonCell.swift */; };
 		6E54675F29F7F8E300F2C3C2 /* GSTextEditorLayoutModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E54675E29F7F8E300F2C3C2 /* GSTextEditorLayoutModifier.swift */; };
@@ -312,6 +314,8 @@
 		6E0F9594298CF5F8000FE529 /* GSTextEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSTextEditor.swift; sourceTree = "<group>"; };
 		6E128D6429A3BDFF0004AEC8 /* ImageCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheManager.swift; sourceTree = "<group>"; };
 		6E128D6629A498A50004AEC8 /* Image+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image+.swift"; sourceTree = "<group>"; };
+		6E1FC6542A115ABD003A77CB /* Int+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+.swift"; sourceTree = "<group>"; };
+		6E1FC6562A116833003A77CB /* CGFloat+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGFloat+.swift"; sourceTree = "<group>"; };
 		6E38C6032991EF380043A8BB /* ChatListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatListCell.swift; sourceTree = "<group>"; };
 		6E38C6052991EF590043A8BB /* ChatListSkeletonCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatListSkeletonCell.swift; sourceTree = "<group>"; };
 		6E54675E29F7F8E300F2C3C2 /* GSTextEditorLayoutModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSTextEditorLayoutModifier.swift; sourceTree = "<group>"; };
@@ -855,6 +859,8 @@
 				70BB6CDF299B105B009948FC /* URL+DeepLink.swift */,
 				22E9ECF0299BA78400D5A9C6 /* UIScreen+.swift */,
 				2205F244299D2B2B00B2643D /* Date+.swift */,
+				6E1FC6542A115ABD003A77CB /* Int+.swift */,
+				6E1FC6562A116833003A77CB /* CGFloat+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1032,6 +1038,7 @@
 				70DB32B02989FA40004E82AD /* Button+ColorScheme.swift in Sources */,
 				680C199F29937CAD009AF5D5 /* SigninView.swift in Sources */,
 				687AE550298FA22500113ABF /* Repository.swift in Sources */,
+				6E1FC6552A115ABD003A77CB /* Int+.swift in Sources */,
 				22DECDEA2976FEB5008A4405 /* ActivityFeedView.swift in Sources */,
 				22DECDE62976F78C008A4405 /* ActivityView.swift in Sources */,
 				70D8DFDD29A4B3C70014AD5A /* PushNotificationMessageBody.swift in Sources */,
@@ -1117,6 +1124,7 @@
 				7065B459297A1F51000B91D2 /* GSButton.swift in Sources */,
 				22B1F2A8299235460010FD15 /* SystemNotificationCell.swift in Sources */,
 				2205F23F299CC04400B2643D /* FollowerResponse.swift in Sources */,
+				6E1FC6572A116833003A77CB /* CGFloat+.swift in Sources */,
 				6E0840272983BB9A00F51169 /* UserInfo.swift in Sources */,
 				22C5412D298CD22500CC89EC /* View+cornerRadius.swift in Sources */,
 				22958CAA29C7529700786357 /* TargetUserProfileView.swift in Sources */,

--- a/GitSpace/Utilities/Components/GSTextEditor.swift
+++ b/GitSpace/Utilities/Components/GSTextEditor.swift
@@ -112,6 +112,14 @@ struct GSTextEditor {
                 autoLineBreakCount(textEditorWidth: textEditorWidth)
             )
             
+        // MARK: text가 가질 수 있는 최대 길이를 세팅해주는 메서드
+        private func setMaxTextWidth(proxy: GeometryProxy) {
+            maxTextWidth = proxy.size.width - (const.TEXTEDITOR_INSET_HORIZONTAL * 2 + 10)
+        }
+        
+        // MARK: line count를 통해 textEditor 현재 높이를 계산해서 업데이트하는 메서드
+        private func updateTextEditorCurrentHeight() {
+
             // 총 라인 갯수
             let floatTotalLineCount = floatNewLineCounter + floatAutoLineBreakCount
             

--- a/GitSpace/Utilities/Components/GSTextEditor.swift
+++ b/GitSpace/Utilities/Components/GSTextEditor.swift
@@ -1,7 +1,7 @@
 // MARK: -Process
 /// 1. TextEditor에 쓰일 Font를 전달받는다
 /// 2. Font를 UIFont로 변환한 연산 프로퍼티를 통해 텍스트 한 줄의 높이를 계산한다 (lineHeight)
-/// 3. 행간을 추가로 max 높이에 더해주기 위해 줄 간격을 필수 파라미터로 받는다
+/// 3. 행간을 추가로 max 높이에 더해주기 위해 라인 간격을 필수 파라미터로 받는다
 /// 4. Font 높이, 라인 갯수, 행간, 여유공간을 모두 더해서 TextEditor 높이를 실시간으로 업데이트한다
 ///
 
@@ -34,52 +34,41 @@ struct GSTextEditor {
         let lineSpace: CGFloat
         let isBlocked: Bool
         
+        // MARK: Initializer에서 계산을 통해 결정되는 프로퍼티
+        let maxLineCount: CGFloat
+        let uiFont: UIFont
+        let maxHeight: CGFloat
+        
         // MARK: SendButton 관련 프로퍼티
         let sendableImage: String
         let unSendableImage: String
         let action: () -> Void
         
-        
-        @State private var textEditorHeight: CGFloat = 0
-        @State private var stateTextWidth: CGFloat = 0
+        @State private var currentTextEditorHeight: CGFloat = 0
+        @State private var maxTextWidth: CGFloat = 0
         
         // MARK: Computed Properties
-        // font 사이즈 관련 프로퍼티를 활용하기 위해 Font -> UIFont로 변환
-        private var mainUIFont: UIFont {
-            return UIFont.fontToUIFont(from: .body)
-        }
-        
-        // font의 한 줄 높이를 계산하는 프로퍼티
-        private var mainFontLineHeight: CGFloat {
-            return mainUIFont.lineHeight
-        }
-        
-        // TextEditor가 5줄을 초과했는지 검사하기 위한 프로퍼티
-        private var maxTextEditorHeight: CGFloat {
-            return mainFontLineHeight * CGFloat(const.TEXTEDITOR_MAX_LINE_COUNT)
-        }
-        
-        /// 현재 text가 몇 줄인지 반환하는 프로퍼티
-        /// 개행문자 갯수 + 1 = maxLineCount
-        /// 개행문자가 maxNewLineCount개 초과일 때, 해당 갯수로 고정
-        /// 입력이 없을 때도 한 줄에 대한 최소 높이가 필요하므로 + 1
-        private var newLineCounter: Int {
+        // 현재 text에 개행문자에 의한 라인 갯수가 몇 줄인지 계산하는 프로퍼티
+        private var newLineCount: CGFloat {
             let currentText: String = text.wrappedValue
-            let currentNewLineCount: Int = currentText.filter{$0 == "\n"}.count
-            let maxNewLineCount: Int = const.TEXTEDITOR_MAX_LINE_COUNT - 1
-            return (currentNewLineCount > maxNewLineCount
-                    ? maxNewLineCount
-                    : currentNewLineCount) + 1
+            let currentLineCount: Int = currentText.filter{$0 == "\n"}.count + 1
+            return currentLineCount > maxLineCount.asInt
+            ? maxLineCount
+            : currentLineCount.asFloat
         }
         
-        // 현재 텍스트의 길이를 계산하는 프로퍼티
-        private var textWidth: CGFloat {
-            let lastLinetext = text.wrappedValue
-            let label = UILabel()
-            label.font = .fontToUIFont(from: font)
-            label.text = lastLinetext
-            label.sizeToFit()
-            return label.frame.width
+        // 개행 문자 기준으로 텍스트를 분리하고, 각 텍스트 길이가 Editor 길이를 초과하는지 체크하여 필요한 줄바꿈 수를 계산하는 프로퍼티
+        private var autoLineCount: CGFloat {
+            var counter: Int = 0
+            text.wrappedValue.components(separatedBy: "\n").forEach { line in
+                let label = UILabel()
+                label.font = .fontToUIFont(from: font)
+                label.text = line
+                label.sizeToFit()
+                let currentTextWidth = label.frame.width
+                counter += (currentTextWidth / maxTextWidth).asInt
+            }
+            return counter.asFloat
         }
         
         // 메세지 문자열이 비어있는지, 공백으로만 이루어져있는지를 체크해서 메시지 전송 가능 여부를 반환하는 연산 프로퍼티
@@ -94,69 +83,6 @@ struct GSTextEditor {
             return true
         }
         
-        // MARK: -Methods
-        // MARK: Method - 시작 textEditor 높이를 세팅해주는 메서드
-        private func setTextEditorStartHeight() {
-            textEditorHeight = mainFontLineHeight + const.TEXTEDITOR_FRAME_HEIGHT_FREESPACE
-        }
-        
-        // MARK: Method - line count를 통해 textEditor 현재 높이를 계산해서 업데이트하는 메서드
-        // TextEditor (줄 갯수 * 폰트 높이) + (줄 갯수 * 자간) + 잘림 방지 여유 공간
-        private func updateTextEditorCurrentHeight(textEditorWidth: CGFloat) {
-            
-            // 개행문자 갯수
-            let floatNewLineCounter = CGFloat(newLineCounter)
-            
-            // 텍스트 길이에 의한 자동 줄바꿈 갯수
-            let floatAutoLineBreakCount = CGFloat(
-                autoLineBreakCount(textEditorWidth: textEditorWidth)
-            )
-            
-        // MARK: text가 가질 수 있는 최대 길이를 세팅해주는 메서드
-        private func setMaxTextWidth(proxy: GeometryProxy) {
-            maxTextWidth = proxy.size.width - (const.TEXTEDITOR_INSET_HORIZONTAL * 2 + 10)
-        }
-        
-        // MARK: line count를 통해 textEditor 현재 높이를 계산해서 업데이트하는 메서드
-        private func updateTextEditorCurrentHeight() {
-
-            // 총 라인 갯수
-            let floatTotalLineCount = floatNewLineCounter + floatAutoLineBreakCount
-            
-            // 라인 갯수로 계산한 현재 Editor 높이
-            let tempTextEditorHeight = (floatTotalLineCount * mainFontLineHeight)
-            + floatTotalLineCount * lineSpace
-            + const.TEXTEDITOR_FRAME_HEIGHT_FREESPACE
-            
-            // 최대 줄 갯수
-            let floatMaxLineCount = CGFloat(const.TEXTEDITOR_MAX_LINE_COUNT)
-            
-            // 최대 줄 갯수 기준 Editor 높이
-            let maxHeight = mainFontLineHeight * floatMaxLineCount
-            + lineSpace * floatMaxLineCount
-            + const.TEXTEDITOR_FRAME_HEIGHT_FREESPACE
-
-            // 계산한 Editor 높이가 최대 Editor 높이보다 크면 최대 Editor 높이로 고정
-            textEditorHeight = tempTextEditorHeight > maxHeight
-            ? maxHeight
-            : tempTextEditorHeight
-        }
-        
-        // MARK: Method - 개행 문자 기준으로 텍스트를 분리하고, 각 텍스트 길이가 Editor 길이를 초과하는지 계산하여 필요한 줄바꿈 수를 반환하는 메서드
-        private func autoLineBreakCount(textEditorWidth: CGFloat) -> Int {
-            var counter: Int = 0
-            text.wrappedValue.components(separatedBy: "\n").forEach { line in
-                let label = UILabel()
-                label.font = .fontToUIFont(from: font)
-                label.text = line
-                label.sizeToFit()
-                if label.frame.width > textEditorWidth {
-                    counter = Int(label.frame.width / textEditorWidth)
-                }
-            }
-            return counter
-        }
-
         // MARK: -Initializer
         /// 파라미터 font = .body, lineSpace = 2 기본값 지정
         init (
@@ -174,11 +100,46 @@ struct GSTextEditor {
             self.font = font
             self.lineSpace = lineSpace
             self.isBlocked = isBlocked
+            
             self.sendableImage = sendableImage
             self.unSendableImage = unSendableImage
             self.action = action
+            
+            self.maxLineCount = const.TEXTEDITOR_MAX_LINE_COUNT.asFloat
+            self.uiFont = UIFont.fontToUIFont(from: font)
+            self.maxHeight = (maxLineCount * (uiFont.lineHeight + lineSpace)) + const.TEXTEDITOR_FRAME_HEIGHT_FREESPACE
         }
         
+        // MARK: -Methods
+        // MARK: textEditor 시작 높이를 세팅해주는 메서드
+        private func setTextEditorStartHeight() {
+            currentTextEditorHeight = uiFont.lineHeight + const.TEXTEDITOR_FRAME_HEIGHT_FREESPACE
+        }
+        
+        // MARK: text가 가질 수 있는 최대 길이를 세팅해주는 메서드
+        private func setMaxTextWidth(proxy: GeometryProxy) {
+            maxTextWidth = proxy.size.width - (const.TEXTEDITOR_INSET_HORIZONTAL * 2 + 10)
+        }
+        
+        // MARK: line count를 통해 textEditor 현재 높이를 계산해서 업데이트하는 메서드
+        private func updateTextEditorCurrentHeight() {
+            
+            // 총 라인 갯수
+            let totalLineCount = newLineCount + autoLineCount
+            
+            // 총 라인 갯수가 maxCount 이상이면 최대 높이로 고정
+            guard totalLineCount < maxLineCount else {
+                currentTextEditorHeight = maxHeight
+                return
+            }
+            
+            // 라인 갯수로 계산한 현재 Editor 높이
+            let currentHeight = (totalLineCount * (uiFont.lineHeight + lineSpace))
+            + const.TEXTEDITOR_FRAME_HEIGHT_FREESPACE
+            
+            // View의 높이를 결정하는 State 변수에 계산된 현재 높이를 할당하여 뷰에 반영
+            currentTextEditorHeight = currentHeight
+        }
         
         // MARK: -View
         var body: some View {
@@ -194,7 +155,7 @@ struct GSTextEditor {
                             font: font,
                             color: .gsGray1,
                             lineSpace: lineSpace,
-                            maxHeight: textEditorHeight,
+                            maxHeight: currentTextEditorHeight,
                             horizontalInset: const.TEXTEDITOR_INSET_HORIZONTAL,
                             bottomInset: const.TEXTEDITOR_INSET_BOTTOM
                         )
@@ -222,7 +183,7 @@ struct GSTextEditor {
                                         font: font,
                                         color: .primary,
                                         lineSpace: lineSpace,
-                                        maxHeight: textEditorHeight,
+                                        maxHeight: currentTextEditorHeight,
                                         horizontalInset: const.TEXTEDITOR_INSET_HORIZONTAL,
                                         bottomInset: const.TEXTEDITOR_INSET_BOTTOM
                                     )
@@ -234,43 +195,37 @@ struct GSTextEditor {
                                 }
                                 .onAppear {
                                     setTextEditorStartHeight()
+                                    setMaxTextWidth(proxy: proxy)
                                 }
                                 .onChange(of: text.wrappedValue) { n in
-                                    // FIXME: 현재 버퍼값으로는 텍스트 길이와 에디터 길이 사이의 공식을 정확하게 구하지 못함 -> 당장 작동은 하지만 정확한 값을 구해서 수정 필요 By. 태영
-                                    let textEditorWidth = proxy.size.width - (const.TEXTEDITOR_INSET_HORIZONTAL * 2 + 10)
-                                    let autoLineBreakCounter = autoLineBreakCount(textEditorWidth: textEditorWidth)
-                                    let multiTextEditorWidth = textEditorWidth - CGFloat(autoLineBreakCounter * 2)
-                                    
-                                    updateTextEditorCurrentHeight(textEditorWidth: multiTextEditorWidth)
-                                }
-                                .onChange(of: textWidth) { newValue in
-                                    stateTextWidth = newValue
+                                    updateTextEditorCurrentHeight()
                                 }
                         }
-                        .frame(maxHeight: textEditorHeight)
-                        
-                        Button {
-                            action()
-                        } label: {
-                            Image(
-                                systemName: isMessageSendable
-                                ? sendableImage
-                                : unSendableImage
-                            )
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(
-                                width: const.TEXTEDITOR_SEND_BUTTON_SIZE,
-                                height: const.TEXTEDITOR_SEND_BUTTON_SIZE
-                            )
-                            .foregroundColor(
-                                isMessageSendable
-                                ? .primary
-                                : .gsGray2
-                            )
-                        }
-                        .disabled(!isMessageSendable)
+                        .frame(maxHeight: currentTextEditorHeight)
                     }
+                    
+                    Button {
+                        action()
+                    } label: {
+                        Image(
+                            systemName: isMessageSendable
+                            ? sendableImage
+                            : unSendableImage
+                        )
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(
+                            width: const.TEXTEDITOR_SEND_BUTTON_SIZE,
+                            height: const.TEXTEDITOR_SEND_BUTTON_SIZE
+                        )
+                        .foregroundColor(
+                            isMessageSendable
+                            ? .primary
+                            : .gsGray2
+                        )
+                    }
+                    .disabled(!isMessageSendable)
+                    
                 }
             }
         }

--- a/GitSpace/Utilities/Extensions/CGFloat+.swift
+++ b/GitSpace/Utilities/Extensions/CGFloat+.swift
@@ -1,0 +1,19 @@
+//
+//  CGFloat+.swift
+//  GitSpace
+//
+//  Created by 원태영 on 2023/05/15.
+//
+
+import Foundation
+
+extension CGFloat {
+    var asInt: Int {
+        switch self {
+        case .infinity, .nan:
+            return 0
+        default:
+            return Int(self)
+        }
+    }
+}

--- a/GitSpace/Utilities/Extensions/Int+.swift
+++ b/GitSpace/Utilities/Extensions/Int+.swift
@@ -1,0 +1,14 @@
+//
+//  Int+.swift
+//  GitSpace
+//
+//  Created by 원태영 on 2023/05/15.
+//
+
+import Foundation
+
+extension Int {
+    var asFloat: CGFloat {
+        return CGFloat(self)
+    }
+}


### PR DESCRIPTION
## 개요 및 관련 이슈
- 텍스트 길이에 의한 자동 줄바꿈 감지를 구현하면서 복잡해진 GSTextEditor 파일의 코드를 정리했습니다.

## 작업 사항
- 최초 1회 연산만 필요한 프로퍼티를 연산 프로퍼티에서 저장 프로퍼티로 변경 후 이니셜라이저에서 계산하여 할당하도록 변경
- 미사용 프로퍼티, 메서드, 중복 로직 삭제
- 프로퍼티/메서드 이름을 직관적으로 이해할 수 있도록 변경
- guard 조건 추가로 연산이 필요하지 않은 경우 빠르게 리턴하여 성능 개선

## 주요 로직

### 이니셜라이저
```swift
// MARK: -Initializer
/// 파라미터 font = .body, lineSpace = 2 기본값 지정
init (
    style: GSTextEditorStyle,
    text: Binding<String>,
    font: Font = .body,
    lineSpace: CGFloat = 2,
    isBlocked: Bool,
    sendableImage: String,
    unSendableImage: String,
    action: @escaping () -> Void
) {
    self.style = style
    self.text = text
    self.font = font
    self.lineSpace = lineSpace
    self.isBlocked = isBlocked
    
    self.sendableImage = sendableImage
    self.unSendableImage = unSendableImage
    self.action = action
    
    self.maxLineCount = const.TEXTEDITOR_MAX_LINE_COUNT.asFloat
    self.uiFont = UIFont.fontToUIFont(from: font)
    self.maxHeight = (maxLineCount * (uiFont.lineHeight + lineSpace)) + const.TEXTEDITOR_FRAME_HEIGHT_FREESPACE
}
```

### 메서드에서 활용하는 연산 프로퍼티
```swift
// MARK: Computed Properties
// 현재 text에 개행문자에 의한 라인 갯수가 몇 줄인지 계산하는 프로퍼티
private var newLineCount: CGFloat {
    let currentText: String = text.wrappedValue
    let currentLineCount: Int = currentText.filter{$0 == "\n"}.count + 1
    return currentLineCount > maxLineCount.asInt
    ? maxLineCount
    : currentLineCount.asFloat
}

// 개행 문자 기준으로 텍스트를 분리하고, 각 텍스트 길이가 Editor 길이를 초과하는지 체크하여 필요한 줄바꿈 수를 계산하는 프로퍼티
private var autoLineCount: CGFloat {
    var counter: Int = 0
    text.wrappedValue.components(separatedBy: "\n").forEach { line in
        let label = UILabel()
        label.font = .fontToUIFont(from: font)
        label.text = line
        label.sizeToFit()
        let currentTextWidth = label.frame.width
        counter += (currentTextWidth / maxTextWidth).asInt
    }
    return counter.asFloat
}
```

### 텍스트에디터 높이 계산 메서드

```swift
// MARK: line count를 통해 textEditor 현재 높이를 계산해서 업데이트하는 메서드
private func updateTextEditorCurrentHeight() {
    
    // 총 라인 갯수
    let totalLineCount = newLineCount + autoLineCount
    
    // 총 라인 갯수가 maxCount 이상이면 최대 높이로 고정
    guard totalLineCount < maxLineCount else {
        currentTextEditorHeight = maxHeight
        return
    }
    
    // 라인 갯수로 계산한 현재 Editor 높이
    let currentHeight = (totalLineCount * (uiFont.lineHeight + lineSpace))
    + const.TEXTEDITOR_FRAME_HEIGHT_FREESPACE
    
    // View의 높이를 결정하는 State 변수에 계산된 현재 높이를 할당하여 뷰에 반영
    currentTextEditorHeight = currentHeight
}
```
