### PR TITLE
[Fix] View Profile → Chat/Knock View → View Profile의 무한 라우팅을 해결했습니다.

### DIFF
--- a/GitSpace/Sources/Router/KnockCommunicationRouter.swift
+++ b/GitSpace/Sources/Router/KnockCommunicationRouter.swift
@@ -65,32 +65,34 @@ struct KnockCommunicationRouter: View {
                 LoadingProgressView()
             }
         }
-        .task {
-            if let targetUserInfo = await userStore.requestUserInfoWithGitHubID(githubID: targetGithubUser.id) {
-                self.targetUserInfo = targetUserInfo
-                let result = await knockViewManager.checkIfKnockHasBeenSent(
-                    currentUser: userStore.currentUser ?? .getFaliedUserInfo(),
-                    targetUser: targetUserInfo
-                )
-                
-                switch result {
-                case let .knockHasBeenSent(knockStatus, withKnock, toChatID):
-                    if let withKnock {
-                        self.knock = withKnock
-                        self.knockStateFilter = knockStatus
-                        
-                        if knockStatus == .accepted,
-                           let toChatID {
-                            self.chat = await chatViewManager.requestPushedChat(chatID: toChatID)
+        .onViewDidLoad {
+            Task {
+                if let targetUserInfo = await userStore.requestUserInfoWithGitHubID(githubID: targetGithubUser.id) {
+                    self.targetUserInfo = targetUserInfo
+                    let result = await knockViewManager.checkIfKnockHasBeenSent(
+                        currentUser: userStore.currentUser ?? .getFaliedUserInfo(),
+                        targetUser: targetUserInfo
+                    )
+                    
+                    switch result {
+                    case let .knockHasBeenSent(knockStatus, withKnock, toChatID):
+                        if let withKnock {
+                            self.knock = withKnock
+                            self.knockStateFilter = knockStatus
+                            
+                            if knockStatus == .accepted,
+                               let toChatID {
+                                self.chat = await chatViewManager.requestPushedChat(chatID: toChatID)
+                            }
+                        }
+                    case let .ableToSentNewKnock(KnockFlag):
+                        // true일 때만 할당하도록 하여 불필요한 뷰 렌더링 최소화
+                        if KnockFlag {
+                            self.isKnockSendable = KnockFlag
                         }
                     }
-                case let .ableToSentNewKnock(KnockFlag):
-                    // true일 때만 할당하도록 하여 불필요한 뷰 렌더링 최소화
-                    if KnockFlag {
-                        self.isKnockSendable = KnockFlag
-                    }
+                    self.isFetchDone.toggle()
                 }
-                self.isFetchDone.toggle()
             }
         }
     }

--- a/GitSpace/Sources/Views/Common/TopperProfileView.swift
+++ b/GitSpace/Sources/Views/Common/TopperProfileView.swift
@@ -41,7 +41,7 @@ struct TopperProfileView: View {
             
             // MARK: - 프로필 이동 버튼
             GSNavigationLink(style: .secondary()) {
-                TargetUserProfileView(user: GithubUser(id: targetUserInfo.githubID, login: targetUserInfo.githubLogin, name: targetUserInfo.githubName, email: targetUserInfo.githubEmail, avatar_url: targetUserInfo.avatar_url, bio: targetUserInfo.bio, company: targetUserInfo.company, location: targetUserInfo.location, blog: targetUserInfo.blog, public_repos: targetUserInfo.public_repos, followers: targetUserInfo.followers, following: targetUserInfo.following))
+                TargetUserProfileView(user: GithubUser(id: targetUserInfo.githubID, login: targetUserInfo.githubLogin, name: targetUserInfo.githubName, email: targetUserInfo.githubEmail, avatar_url: targetUserInfo.avatar_url, bio: targetUserInfo.bio, company: targetUserInfo.company, location: targetUserInfo.location, blog: targetUserInfo.blog, public_repos: targetUserInfo.public_repos, followers: targetUserInfo.followers, following: targetUserInfo.following), isFromTopperProfileView: true)
             } label: {
                 Text("View Profile")
                     .font(.footnote)

--- a/GitSpace/Sources/Views/Common/TopperProfileView.swift
+++ b/GitSpace/Sources/Views/Common/TopperProfileView.swift
@@ -40,7 +40,11 @@ struct TopperProfileView: View {
             
             // MARK: - 프로필 이동 버튼
             GSNavigationLink(style: .secondary()) {
-                TargetUserProfileView(user: GithubUser(id: targetUserInfo.githubID, login: targetUserInfo.githubLogin, name: targetUserInfo.githubName, email: targetUserInfo.githubEmail, avatar_url: targetUserInfo.avatar_url, bio: targetUserInfo.bio, company: targetUserInfo.company, location: targetUserInfo.location, blog: targetUserInfo.blog, public_repos: targetUserInfo.public_repos, followers: targetUserInfo.followers, following: targetUserInfo.following), isFromTopperProfileView: true)
+                TargetUserProfileView(
+                    user: gitHubAuthManager
+                        .getGithubUser(FBUser: targetUserInfo),
+                    isFromTopperProfileView: true
+                )
             } label: {
                 Text("View Profile")
                     .font(.footnote)

--- a/GitSpace/Sources/Views/Common/TopperProfileView.swift
+++ b/GitSpace/Sources/Views/Common/TopperProfileView.swift
@@ -8,10 +8,9 @@
 import SwiftUI
 
 struct TopperProfileView: View {
-	@EnvironmentObject var userStore: UserStore
-	@State private var user: UserInfo? = nil
-//	@State var userID: String
-	
+    @EnvironmentObject var userStore: UserStore
+    @EnvironmentObject var gitHubAuthManager: GitHubAuthManager
+    @State private var user: UserInfo? = nil
     let targetUserInfo: UserInfo
     
     var body: some View {

--- a/GitSpace/Sources/Views/Home/ContributorListView.swift
+++ b/GitSpace/Sources/Views/Home/ContributorListView.swift
@@ -190,16 +190,17 @@ Please select a User to start chatting with.
             } else {
                 ContributorListSkeletonView()
             } // else
-            
         } // ScrollView
-        .task {
-            await divideUser()
-            if let githubID = userInfoManager.currentUser?.githubID {
-                self.githubID = githubID
-            } else {
-                let user: UserInfo? = await userInfoManager.requestUserInfoWithID(userID: Utility.loginUserID)
-                if let user {
-                    self.githubID = user.githubID
+        .onViewDidLoad {
+            Task {
+                await divideUser()
+                if let githubID = userInfoManager.currentUser?.githubID {
+                    self.githubID = githubID
+                } else {
+                    let user: UserInfo? = await userInfoManager.requestUserInfoWithID(userID: Utility.loginUserID)
+                    if let user {
+                        self.githubID = user.githubID
+                    }
                 }
             }
         }

--- a/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
+++ b/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
@@ -48,7 +48,10 @@ struct TargetUserProfileView: View {
             
             if isBlockedUser {
                 VStack {
-                    GSText.CustomTextView(style: .title3, string: "This user is blocked user")
+                    GSText.CustomTextView(
+                        style: .title3,
+                        string: "This user is blocked user"
+                    )
                 }
                 .frame(maxWidth: .infinity)
                 .frame(height: 50)
@@ -62,17 +65,29 @@ struct TargetUserProfileView: View {
                 VStack(alignment: .leading) {
                     // MARK: -사람 이미지와 이름, 닉네임 등을 위한 stack.
                     HStack(spacing: 10) {
-                        GithubProfileImage(urlStr: user.avatar_url, size: 60)
+                        GithubProfileImage(
+                            urlStr: user.avatar_url,
+                            size: 60
+                        )
                         VStack(alignment: .leading) {
                             // 유저가 설정한 이름이 존재하는 경우
                             if let name = user.name {
-                                GSText.CustomTextView(style: .title2, string: name)
+                                GSText.CustomTextView(
+                                    style: .title2,
+                                    string: name
+                                )
                                 Spacer()
                                     .frame(height: 8)
                                 // 유저의 깃허브 아이디
-                                GSText.CustomTextView(style: .description, string: user.login)
+                                GSText.CustomTextView(
+                                    style: .description,
+                                    string: user.login
+                                )
                             } else { // 유저가 설정한 이름이 존재하지 않는 경우, 유저의 깃허브 아이디만 보여준다.
-                                GSText.CustomTextView(style: .title2, string: user.login)
+                                GSText.CustomTextView(
+                                    style: .title2,
+                                    string: user.login
+                                )
                             }
                         }
                         Spacer()
@@ -82,7 +97,10 @@ struct TargetUserProfileView: View {
                     if let bio = user.bio {
                         // MARK: - bio
                         HStack() {
-                            GSText.CustomTextView(style: .body1, string: bio)
+                            GSText.CustomTextView(
+                                style: .body1,
+                                string: bio
+                            )
                             Spacer()
                         }
                         .padding(15)
@@ -105,7 +123,10 @@ struct TargetUserProfileView: View {
                                 .frame(width: 15, height: 15)
                                 .foregroundColor(.gsGray2)
                             
-                            GSText.CustomTextView(style: .captionPrimary1, string: company)
+                            GSText.CustomTextView(
+                                style: .captionPrimary1,
+                                string: company
+                            )
                         }
                     }
                     
@@ -118,7 +139,10 @@ struct TargetUserProfileView: View {
                                 .frame(width: 15, height: 15)
                                 .foregroundColor(.gsGray2)
                             
-                            GSText.CustomTextView(style: .captionPrimary1, string: location)
+                            GSText.CustomTextView(
+                                style: .captionPrimary1,
+                                string: location
+                            )
                         }
                     }
                     
@@ -133,8 +157,11 @@ struct TargetUserProfileView: View {
                             
                             if let blogURL = URL(string: blogURLString) {
                                 Link(destination: blogURL) {
-                                    GSText.CustomTextView(style: .captionPrimary1, string: blogURLString)
-                                        .multilineTextAlignment(.leading)
+                                    GSText.CustomTextView(
+                                        style: .captionPrimary1,
+                                        string: blogURLString
+                                    )
+                                    .multilineTextAlignment(.leading)
                                 }
                             }
                         }
@@ -149,12 +176,24 @@ struct TargetUserProfileView: View {
                             .foregroundColor(.gsGray2)
                         
                         NavigationLink {
-                            TargetUserFollowerListView(service: gitHubService, targetUserLogin: user.login, followers: user.followers)
+                            TargetUserFollowerListView(
+                                service: gitHubService,
+                                targetUserLogin: user.login,
+                                followers: user.followers
+                            )
                         } label: {
                             HStack {
-                                GSText.CustomTextView(style: .title4, string: handleCountUnit(countInfo: user.followers))
-                                GSText.CustomTextView(style: .sectionTitle, string: "followers")
-                                    .padding(.leading, -2)
+                                GSText.CustomTextView(
+                                    style: .title4,
+                                    string: handleCountUnit(
+                                        countInfo: user.followers
+                                    )
+                                )
+                                GSText.CustomTextView(
+                                    style: .sectionTitle,
+                                    string: "followers"
+                                )
+                                .padding(.leading, -2)
                             }
                         } // NavigationLink
                         
@@ -164,12 +203,24 @@ struct TargetUserProfileView: View {
                             .padding(.trailing, -9)
                         
                         NavigationLink {
-                            TargetUserFollowingListView(service: gitHubService, targetUserLogin: user.login, following: user.following)
+                            TargetUserFollowingListView(
+                                service: gitHubService,
+                                targetUserLogin: user.login,
+                                following: user.following
+                            )
                         } label: {
                             HStack {
-                                GSText.CustomTextView(style: .title4, string: handleCountUnit(countInfo: user.following))
-                                GSText.CustomTextView(style: .sectionTitle, string: "following")
-                                    .padding(.leading, -2)
+                                GSText.CustomTextView(
+                                    style: .title4,
+                                    string: handleCountUnit(
+                                        countInfo: user.following
+                                    )
+                                )
+                                GSText.CustomTextView(
+                                    style: .sectionTitle,
+                                    string: "following"
+                                )
+                                .padding(.leading, -2)
                             }
                         } // NavigationLink
                     }
@@ -206,11 +257,17 @@ struct TargetUserProfileView: View {
                                 }
                             } label: {
                                 targetUserProfileViewModel.isFollowingUser ?
-                                GSText.CustomTextView(style: .buttonTitle1, string: "✅ Following")
-                                    .frame(maxWidth: .infinity)
+                                GSText.CustomTextView(
+                                    style: .buttonTitle1,
+                                    string: "✅ Following"
+                                )
+                                .frame(maxWidth: .infinity)
                                 :
-                                GSText.CustomTextView(style: .buttonTitle1, string: "➕ Follow")
-                                    .frame(maxWidth: .infinity)
+                                GSText.CustomTextView(
+                                    style: .buttonTitle1,
+                                    string: "➕ Follow"
+                                )
+                                .frame(maxWidth: .infinity)
                             }
                             
                             Spacer()
@@ -222,15 +279,20 @@ struct TargetUserProfileView: View {
                                 ) {
                                     dismiss()
                                 } label: {
-                                    GSText.CustomTextView(style: .buttonTitle1, string: "Knock")
-                                        .frame(maxWidth: .infinity)
+                                    GSText.CustomTextView(
+                                        style: .buttonTitle1,
+                                        string: "Knock"
+                                    )
+                                    .frame(maxWidth: .infinity)
                                 }
                             } else {
                                 GSNavigationLink(style: .secondary()) {
                                     KnockCommunicationRouter(targetGithubUser: user)
                                 } label: {
-                                    GSText.CustomTextView(style: .buttonTitle1, string: "Knock")
-                                        .frame(maxWidth: .infinity)
+                                    GSText.CustomTextView(
+                                        style: .buttonTitle1,
+                                        string: "Knock")
+                                    .frame(maxWidth: .infinity)
                                 }
                             }
                         }
@@ -259,11 +321,17 @@ struct TargetUserProfileView: View {
                             }
                         } label: {
                             targetUserProfileViewModel.isFollowingUser ?
-                            GSText.CustomTextView(style: .buttonTitle1, string: "✅ Following")
-                                .frame(maxWidth: .infinity)
+                            GSText.CustomTextView(
+                                style: .buttonTitle1,
+                                string: "✅ Following"
+                            )
+                            .frame(maxWidth: .infinity)
                             :
-                            GSText.CustomTextView(style: .buttonTitle1, string: "➕ Follow")
-                                .frame(maxWidth: .infinity)
+                            GSText.CustomTextView(
+                                style: .buttonTitle1,
+                                string: "➕ Follow"
+                            )
+                            .frame(maxWidth: .infinity)
                         }
                         .padding(.vertical, 10)
                     }
@@ -282,7 +350,10 @@ struct TargetUserProfileView: View {
                 } else {
                     VStack {
                         HStack {
-                            GSText.CustomTextView(style: .caption2, string: "README.md")
+                            GSText.CustomTextView(
+                                style: .caption2,
+                                string: "README.md"
+                            )
                             Spacer()
                         }
                         
@@ -388,7 +459,6 @@ struct TargetUserProfileView: View {
                         .frame(width: 40, height: 40)
                 }
             }
-            
         } //  body
     }
 }

--- a/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
+++ b/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
@@ -216,11 +216,22 @@ struct TargetUserProfileView: View {
                             Spacer()
                                 .frame(width: 10)
                             
-                            GSNavigationLink(style: .secondary()) {
-                                KnockCommunicationRouter(targetGithubUser: user)
-                            } label: {
-                                GSText.CustomTextView(style: .buttonTitle1, string: "Knock")
-                                    .frame(maxWidth: .infinity)
+                            if isFromTopperProfileView {
+                                GSButton.CustomButtonView(
+                                    style: .secondary(isDisabled: false)
+                                ) {
+                                    dismiss()
+                                } label: {
+                                    GSText.CustomTextView(style: .buttonTitle1, string: "Knock")
+                                        .frame(maxWidth: .infinity)
+                                }
+                            } else {
+                                GSNavigationLink(style: .secondary()) {
+                                    KnockCommunicationRouter(targetGithubUser: user)
+                                } label: {
+                                    GSText.CustomTextView(style: .buttonTitle1, string: "Knock")
+                                        .frame(maxWidth: .infinity)
+                                }
                             }
                         }
                         .padding(.vertical, 10)

--- a/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
+++ b/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
@@ -12,6 +12,7 @@ import RichText
 
 struct TargetUserProfileView: View {
     
+    @Environment(\.dismiss) private var dismiss
     @EnvironmentObject var gitHubAuthManager: GitHubAuthManager
     @EnvironmentObject var userInfoManager: UserStore
     @EnvironmentObject var blockedUsers: BlockedUsers

--- a/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
+++ b/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
@@ -29,11 +29,17 @@ struct TargetUserProfileView: View {
     @State private var targetUserInfo: UserInfo? = nil
     @State private var isBlockedUser: Bool = false
     
+    var isFromTopperProfileView: Bool = false
     let user: GithubUser
     let gitHubService = GitHubService()
     
     init(user: GithubUser) {
         self.user = user
+    }
+    
+    init(user: GithubUser, isFromTopperProfileView: Bool) {
+        self.user = user
+        self.isFromTopperProfileView = isFromTopperProfileView
     }
     
     var body: some View {


### PR DESCRIPTION
## 개요 및 관련 이슈
- `View Profile` → `Chat/Knock View` → `View Profile`의 무한 라우팅을 해결했습니다.
- #424 

## 👷🏻 원인 파악
> 무한 라우팅을 해결하기 위해서는
> 반복적으로 Push 되는 뷰가 있을 경우 `NavigationLink` 등을 통한 뷰 이동을 끊고 이전 뷰로 돌아가야 합니다.
> **GitSpace**에서 무한 라우팅이 발생하는 시나리오는 다음과 같습니다.
### 무한 라우팅이 발생하는 시나리오
1. `Chat View` → `View Profile` 링크 → `Knock`링크
2. `Received Knock View` → `View Profile` 링크 → `Knock` 링크
3. `Send Knock View` → `View Profile` 링크 → `Knock` 링크

### 원인
위의 시나리오에서 공통적으로 `TopperProfileView`의 `View Profile` 링크를 통해
`TargetUserProfileView`로 이동하면서 무한 라우팅이 시작됩니다.

## 🛠️ 해결 방안
`TopperProfileView'의 'View Profile` 링크로 TargetUser의 프로필로 이동 후,
해당 유저 프로필의 `Knock` 링크를 눌렀을 때 이전 뷰로 돌아가도록 해야 합니다.

### 1. Coordinator Pattern (보류)
- **[참고]** [**Coordinator Pattern in SwiftUI**](https://labs.brandi.co.kr//2022/12/12/leehs81.html)
- Coordinator Pattern은 화면전환에 관련된 코드를 Coordinator 라고 하는 별도의 모델로 책임을 분리하는 디자인 패턴 중 하나입니다.
아키텍처로 고도화 할 경우, 모든 화면 전환 로직, 화면 전환 애니메이션 등을 관리할 수 있어서 굉장히 유용한 디자인 패턴 중 하나입니다.
- 현재 버전에서 Coordinator Pattern을 사용하기 위해서는 대대적인 작업이 예상되므로,
출시 후 아키텍처 구조를 개편할 때 이 패턴을 고려해보는 것이 좋을 것 같아 보류하게 되었습니다.

### 2. 트리거 전달 (채택)

1. `TopperProfileView`에서 `View Profile` 링크를 통해 `TargetUserProfileView`로 이동할 때
`TopperProfileView`에서 이동된 것임을 알려주는 `isFromTopperProfileView: Bool = true` 트리거를 전달 합니다.

2. `TargetUserProfileView`의 `Knock` 링크를 `isFromTopperProfileView`의 상태에 따라 분기하여
`dismiss()` 하는 방식을 채택했습니다.

## 📋 작업 사항
### 1. TargetUserProfileView에 isFromTopperProfileView 변수를 생성하고 이를 파라미터로 하는 생성자를 추가하였습니다.
  - **TargetUserProfileView.swift**
    ```swift
    // TargetUserProfileView.swift
    // #32 lines
    // 트리거로 사용하기 위한 변수를 생성합니다.
    var isFromTopperProfileView: Bool = false

    // #40 lines
    // isFromTopperProfileView를 파라미터로 하는 생성자를 추가합니다.
    init(user: GithubUser, isFromTopperProfileView: Bool) {
        self.user = user
        self.isFromTopperProfileView = isFromTopperProfileView
    }
    ```
### 2. isFromTopperProfileView의 값에 따라 `Knock` 버튼 또는 링크로 뷰에 보여주었습니다.
  - **TargetUserProfileView.swift**
    ```swift
    // TargetUserProfileView.swift
    // #219 lines
    // 이전 뷰가 TopperProfileView일 경우,
    // dismiss()하는 버튼으로 보여줍니다.
    if isFromTopperProfileView {                        
        GSButton.CustomButtonView(                
            style: .secondary(isDisabled: false)
        ) {
                dismiss()
        } label: {
            GSText.CustomTextView(style: .buttonTitle1, string: "Knock")
                .frame(maxWidth: .infinity)
        }
    } else {
    // 이전 뷰가 TopperProfileView가 아닐 경우,
    // NavigationLink로 보여줍니다.                                                               
        GSNavigationLink(style: .secondary()) {   
            KnockCommunicationRouter(targetGithubUser: user)
        } label: {
            GSText.CustomTextView(style: .buttonTitle1, string: "Knock")
                .frame(maxWidth: .infinity)
        }
    }
    ```
### 3. TopperProfileView의 `View Profile` 링크에 연결된 뷰에 `isFromTopperProfileView` 파라미터를 추가했습니다.
  - **TopperProfileView.swift**
    ```swift
    // TopperProfileView.swift
    // #43 lines
    
    GSNavigationLink(style: .secondary()) {
        TargetUserProfileView(user: GithubUser(), isFromTopperProfileView: true)
    } label: {
        Text("View Profile")
            .font(.footnote)
            .foregroundColor(.black)
            .bold()
    }
    ```
### 4. `KnockCommunicationRouter`로 dismiss() 할 때, `LoadingProgressView`가 계속 표시되는 것을 방지하기 위해 `.task`를 `.onViewDidLoad`로 변경했습니다.
  - **스크린샷**
  
  | `LoadingProgressView`가 계속 표시되는 모습 |
  | :-----------------------------------------: |
  | <img width="200" alt="image" src="https://github.com/APPSCHOOL1-REPO/finalproject-gitspace/assets/64696968/ffa69a7a-e2b2-406d-8021-ea4fbbf20096"> |

  - **KnockCommunicationRouter.swift**
    ```diff
    // KnockCommunicationRouter.swift
    // #68 lines
    - .task {
    + .onViewDidLoad {
    +    Task {
            // 기존 코드
    +    }
    }
    ```

## 📸 스크린샷
### 무한 라우팅 문제 해결
| 무한 라우팅 | `dismiss()` |
|:------:|:------:|
| <img width="200" alt="image" src="https://github.com/APPSCHOOL1-REPO/finalproject-gitspace/assets/64696968/73bd1705-8253-4c09-8d67-33b7fbc88170"> | <img width="200" alt="image" src="https://github.com/APPSCHOOL1-REPO/finalproject-gitspace/assets/64696968/af0a5fba-838a-41ee-9b7d-5c983a6f92a6"> |

## ✅ 확인한 사항
- [x] `dismiss()`하는 버튼은 `TopperProfileView`로부터 연결된 `TargetUserProfileView`에만 보여지는 것을 확인했습니다.
(Chat / ReceivedKnock / SendKnock의 각 경우를 모두 확인하였습니다.)
- [x] 무한 라우팅이 되지 않는 것을 확인했습니다.

## 📝 확인해야 할 사항
- [ ] `KnockCommunicationRouter`의 `.task`를 `.onViewDidLoad`로 바꿈으로써 생기는 문제가 없는 지 확인해야 합니다.

