### PR TITLE
[Feat] User Listener를 구현했습니다.

### DIFF
--- a/GitSpace/Sources/Router/ContentView.swift
+++ b/GitSpace/Sources/Router/ContentView.swift
@@ -68,12 +68,14 @@ struct ContentView: View {
                 Utility.loginUserID = uid
                 await userStore.requestUser(userID: uid)
                 await userStore.requestUsers()
-                
                 await retrieveBlockedUserList()
-            
+                userStore.addListener()
             } else {
                 print("Error-ContentView-requestUser : Authentication의 uid가 존재하지 않습니다.")
             }
+        }
+        .onDisappear {
+            userStore.removeListener()
         }
     }
     

--- a/GitSpace/Sources/ViewModels/ChatViewModel.swift
+++ b/GitSpace/Sources/ViewModels/ChatViewModel.swift
@@ -57,7 +57,6 @@ final class ChatStore: ObservableObject {
         chats = []
         isDoneFetch = false
         newChat = Chat.emptyChat()
-		targetUserInfoDict = [:]
     }
     
 }


### PR DESCRIPTION
## 개요 및 관련 이슈
- #426 

<br><br>

## User Listener 추가 배경 (작업 목적)
차단 기능이 추가되면서 차단 액션 후 `User`의 차단 목록 업데이트가 필요합니다.

Firestore DB에는 업데이트가 반영되지만, 로컬 `User` 데이터에도 반영이 필요한데, 차단 기능이 `Blockable` 프로토콜에 의존하는 구조로 되어있습니다.

프로토콜 내부에서는 `EnvironmentObject` 사용이 불가해서 앱 전반에서 사용하는 `UserViewModel`에 접근할 수 없기 때문에 차단 기능을 사용하는 모든 View에서 `UserViewModel`을 의존하고 직접 `User` Request 호출까지 별도로 해야하는 상황입니다.

이를 해결하기 위해 Firestore DB의 `User`가 업데이트 될 때, 이를 감지하여 로직을 수행할 수 있는 `Listener`를 구현합니다.

<br><br>

## 작업 사항
- `UserViewModel`의 Extension으로 `addListener`와 `removeListener` 메서드가 추가되었습니다.
- `ContentView` (로그인 직후 첫 진입 뷰) 진입 시 `addListener`, 탈출 시 `removeListener`를 호출하는 코드가 추가되었습니다.

<br><br>

## Listener 구현부
```swift
// MARK: - Listener
extension UserStore {
    func addListener() {
        listener = db
            .collection(const.COLLECTION_USER_INFO)
            .document(Utility.loginUserID)
            .addSnapshotListener { snapshot, error in
                guard let snapshot else { return }
                
                do {
                    Task {
                        let updatedUserInfo: UserInfo = try snapshot.data(as: UserInfo.self)
                        await self.writeUser(user: updatedUserInfo)
                    }
                }
            }
    }
    
    func removeListener() {
        guard let listener else { return }
        listener.remove()
    }
}
```
<br><br>

# Document에 Listener를 추가할 때?

## 기존 프로젝트(Collection)의 Listener
프로젝트에 적용된 기존 Listener `(Chat, Knock)`는 감지 범위를 Collection 단위로 설정했기 때문에 변경된 문서들이 `snapshot.documentChanges`라는 `[DocumentChange]` 타입의 배열로 들어옵니다.

열거형 `DocumentChangeType` 타입의 값인 `type`에서 `.added`(추가), `.modified`(변경), `.removed`(삭제)를 `switch`로 열어서 케이스별로 분기 로직을 처리해주는 형태로 구현되어 있습니다.

```swift
snapshot.documentChanges.forEach { docDiff in
    switch docDiff.type {
    case .added:
       // 문서 추가 시 수행할 로직
    case .modified:
       // 문서 변경 시 수행할 로직
    case .removed:
       // 문서 삭제 시 수행할 로직
    }
}
```
<br><br>
## Document의 Listener
Document 경로에 Listener를 추가하게 되면 컬렉션과 다르게 단일 문서에 대한 변경점을 감지합니다.

이 때 변경된 문서는 위와 다르게 `DocumentChange` 타입으로 반환되지 않고 `DocumentSnapshot`으로 반환되며, 이 타입은 기존의 Document Request 로직에서 사용하는 `getDocument` 메서드의 반환 타입과 동일합니다.

그렇기 때문에 위의 `DocumentChange`처럼 `type` 값을 통한 추가, 변경, 삭제에 대한 분기처리는 불가합니다.

<br><br>

## 문서 추가, 변경, 삭제에 대한 테스트
`type`으로 인한 분기처리가 불가하기 때문에, 실제로 문서가 추가, 변경, 삭제될 때 정상적으로 작동하는지 테스트했습니다.

<br><br>

### Added
기존에 없는 문서를 대상으로 Listener를 추가할수 없어서 테스트용 로직을 통해 확인했습니다.
작동 순서는 아래와 같습니다.
1. uuid 생성
2. 해당 uuid 경로에 Listener 작동
3. DB에 실제 해당 문서 추가
```swift
static func addListener(userUUID: String) {
    db.collection(const.COLLECTION_USER_INFO).document(userUUID)
        .addSnapshotListener { snapshot, error in
            guard let snapshot else { return }
            
            do {
                Task {
                    let data = snapshot.data()
                    if let data {
                        print("문서가 생성되었습니다.\n")
                        data.forEach { (key, value) in
                            print(key, ":", value)
                        }
                        print("\n\n")
                    }
                    
                }
            }
        }
}
```

<img width="600" alt="added" src="https://github.com/APPSCHOOL1-REPO/finalproject-gitspace/assets/45925685/aadee24f-b511-4eb1-977a-bd2367442dc2">

문서가 추가되는순간 감지해서 작동합니다.

<br><br>

### Modified
`Modified`는 문서 내 필드의 변경 요소가 발생했을 때입니다.

이번 리스너 구현의 목적이기도 한 차단 업데이트 반영으로 테스트해보았습니다.

```swift
func addListener() {
        listener = db
            .collection(const.COLLECTION_USER_INFO)
            .document(Utility.loginUserID)
            .addSnapshotListener { snapshot, error in
                guard let snapshot else { return }
                
                do {
                    Task {
                        print("Task 진입 \n")
                        print("문서 필드 갯수 :",snapshot.data()?.count ?? 100, "\n")
                        print("차단 유저 리스트 - 변경 전 :", self.user?.blockedUserIDs ?? [], "\n")
                        let updatedUserInfo: UserInfo = try snapshot.data(as: UserInfo.self)
                        print("Document -> UserInfo 변환 성공 \n")
                        await self.writeUser(user: updatedUserInfo)
                        print("User 할당 성공 \n")
                        print("차단 유저 리스트 - 변경 후 :", self.user?.blockedUserIDs ?? [], "\n")
                    }
                }
            }
    }
```

차단
<img width="600" alt="blocked" src="https://github.com/APPSCHOOL1-REPO/finalproject-gitspace/assets/45925685/c50f0044-54e1-4070-a568-b18bee6d09b9">

차단 해제
<img width="600" alt="unblocked" src="https://github.com/APPSCHOOL1-REPO/finalproject-gitspace/assets/45925685/819e96af-f4fa-4f0b-9f1e-10a82bd4c270">

두 케이스 모두 변경을 잘 감지하고 `ViewModel`의 `User` 객체도 정상적으로 업데이트 됩니다.

<br><br>

### Removed
`Removed`는 해당 문서가 삭제될 때입니다.

<img width="362" alt="removed" src="https://github.com/APPSCHOOL1-REPO/finalproject-gitspace/assets/45925685/cbb81606-293c-4595-9792-6b6e6333503d">

문서가 삭제될 때는 `documentSnapshot`까지는 반환되지만, 문서가 삭제되어 필드가 없기 때문에 `data?`가 nil이 되어서 `count`가 ?? 뒤에 있는 100으로 출력됩니다.

또한, 디코딩에 실패해서 `do` 스코프를 탈출하여 해당 코드 아래로는 `print`문이 실행되지 않은 것을 확인할 수 있습니다.

<br><br>

## 결론 3줄 요약
1. 추가될 문서 ID를 추가되기 전에 알 수 있다면, `Added` 케이스에 대한 로직도 수행할 수 있다.
2. 일반적으로는 변경, 삭제에 대한 로직을 수행하는 용도로 사용한다.
3. `document.data()`가 `nil`인지 여부로 `Modified`, `Removed`는 분기처리가 가능하다.

