### PR TITLE
[Fix] GitSpace 유저 검증 로직을 수정하였습니다.

### DIFF
--- a/GitSpace/Sources/Router/ContentView.swift
+++ b/GitSpace/Sources/Router/ContentView.swift
@@ -67,8 +67,6 @@ struct ContentView: View {
 				// userInfo 할당
                 Utility.loginUserID = uid
                 await userStore.requestUser(userID: uid)
-                await userStore.requestUsers()
-                
                 await retrieveBlockedUserList()
             
             } else {

--- a/GitSpace/Sources/Views/Home/ContributorListView.swift
+++ b/GitSpace/Sources/Views/Home/ContributorListView.swift
@@ -23,13 +23,13 @@ struct ContributorListView: View {
     }
     
     @State var gitSpaceUserList: [Int] = []
-    @State var isDevided: Bool = false
+    @State var isDivided: Bool = false
     @State private var githubID: Int = 0
     
     func divideUser() async {
         
         withAnimation(.easeInOut) {
-            isDevided = false
+            isDivided = false
         }
         
         gitSpaceUserList.removeAll()
@@ -41,7 +41,7 @@ struct ContributorListView: View {
         }
         
         withAnimation(.easeInOut) {
-            isDevided = true
+            isDivided = true
         }
     }
     
@@ -49,7 +49,7 @@ struct ContributorListView: View {
     var body: some View {
         
         ScrollView {
-            if isDevided == true {
+            if isDivided == true {
                 // MARK: - 상황별 마스코트 이미지
                 /* 노트 시나리오의 시각적 힌트 제공 */
                 HStack {
@@ -65,7 +65,7 @@ struct ContributorListView: View {
                 } // HStack
                 
                 HStack {
-                    if gitSpaceUserList.isEmpty && isDevided == true {
+                    if gitSpaceUserList.isEmpty && isDivided == true {
                         // MARK: - 저장소의 기여자들 중 GitSpace User가 없을 경우
                         GSText.CustomTextView(
                             style: .title2,

--- a/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
+++ b/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
@@ -5,8 +5,8 @@
 //  Created by 박제균 on 2023/02/14.
 //
 
-import SwiftUI
 import RichText
+import SwiftUI
 
 // MARK: - gitHubUser 필요
 
@@ -331,11 +331,11 @@ struct TargetUserProfileView: View {
             }
         }
         .sheet(isPresented: $isReportViewShowing) {
-            if let targetUser = targetUserInfo {
+            if let targetUserInfo {
                 ReportView(
                     isReportViewShowing: $isReportViewShowing,
                     isSuggestBlockViewShowing: $isSuggestBlockViewShowing,
-                    targetUser: targetUser
+                    targetUser: targetUserInfo
                 )
             }
         }

--- a/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
+++ b/GitSpace/Sources/Views/Profile/TargetUserProfileView.swift
@@ -288,12 +288,10 @@ struct TargetUserProfileView: View {
             } else {
                 isBlockedUser = false
             }
-            isGitSpaceUser = userInfoManager.users.contains { $0.githubID == user.id }
         }
         .task {
             targetUserInfo = await userInfoManager.requestUserInfoWithGitHubID(githubID: user.id)
-            isGitSpaceUser = userInfoManager.users.contains { $0.githubLogin == self.user.login }
-            
+            targetUserInfo == nil ? (isGitSpaceUser = false) : (isGitSpaceUser = true)
             let readMeRequestResult = await targetUserProfileViewModel.requestUserReadme(user: user.login)
             let isFollowingTargetUser = await targetUserProfileViewModel.checkAuthenticatedUserIsFollowing(who: user.login)
             


### PR DESCRIPTION
## 개요 및 관련 이슈
- #422 

## 작업 사항
- GitSpace 유저 검증 로직을 수정하였습니다.
- 신고와 차단 기능이 추가되면서, TargetUserProfileView에서 BlockView 및 ReportView에 UserInfo 타입의 구조체를 주입하고 있습니다. (신고 및 차단은 GitSpace 유저간의 활동이기 때문)
- **TargetUserProfileView에서 사용되는 GitHubUser 타입의 구조체**와는 달리, **BlockView 및 ReportView에서는 UserInfo 타입의 구조체**가 필요합니다. 
- 따라서 TargetUserProfileView에 진입시, GitHubUser의 id를 사용하여 Firestore db에서 쿼리를 실행하여 해당 github id를 가진 유저가 있다면 **UserInfo** 타입의 구조체를 리턴하고, 없다면 nil을 리턴하는 `.requestUserInfoWithGitHubID(githubID: )` 메서드를 사용합니다.
- 즉, 해당 메서드의 리턴값이 nil이라면, GitSpace를 사용하는 모든 유저를 저장하고 있는 Firestore의 UserInfo Collection에 해당 GitHub ID를 가진 유저가 없다는 뜻이고, 이는 즉 GitSpace 유저가 아니라는 의미를 내포합니다.
- 기존 검증 로직이었던 ContentView에서 `UserStore.requestUsers()`메서드를 실행하여 모든 GitSpace 유저를 일일히 배열에 저장한 뒤 비교하는 방법을 사용하지 않고도 GitSpace 유저임을 검증할 수 있습니다.
- 이에 따라 기존 GitSpace 유저 검증 코드를 제거하였고 관련 파일들을 수정하였습니다.

## 주요 로직(Optional)
```Swift
.task {
    targetUserInfo = await userInfoManager.requestUserInfoWithGitHubID(githubID: user.id)
    targetUserInfo == nil ? (isGitSpaceUser = false) : (isGitSpaceUser = true)
    ...
}
```
