### PR TITLE
[Fix] userViewModel의 user와 currentUser를 통합했습니다.

### DIFF
--- a/GitSpace/GitSpaceApp.swift
+++ b/GitSpace/GitSpaceApp.swift
@@ -22,6 +22,7 @@ struct GitSpaceApp: App {
 
             InitialView(tabBarRouter: tabBarRouter)
                 .environmentObject(ChatStore())
+                .environmentObject(UserStore())
                 .environmentObject(MessageStore())
                 .environmentObject(RepositoryViewModel(service: GitHubService()))
                 .environmentObject(TagViewModel())

--- a/GitSpace/InitialView.swift
+++ b/GitSpace/InitialView.swift
@@ -11,7 +11,6 @@ import FirebaseAuth
 struct InitialView: View {
     @EnvironmentObject var githubAuthManager: GitHubAuthManager
     @EnvironmentObject var pushNotificationManager: PushNotificationManager
-    @StateObject var userStore = UserStore(currentUserID: Auth.auth().currentUser?.uid ?? "")
     let tabBarRouter: GSTabBarRouter
     
     // MARK: - 한호
@@ -36,7 +35,6 @@ struct InitialView: View {
             case .signedIn:
                 ContentView(tabBarRouter: tabBarRouter)
                     .preferredColorScheme(selectedAppearance)
-                    .environmentObject(userStore)
             case .pending:
                 LoadingProgressView()
                     .preferredColorScheme(selectedAppearance)

--- a/GitSpace/Sources/Router/ContentView.swift
+++ b/GitSpace/Sources/Router/ContentView.swift
@@ -68,7 +68,6 @@ struct ContentView: View {
                 Utility.loginUserID = uid
                 await userStore.requestUser(userID: uid)
                 await userStore.requestUsers()
-                
                 await retrieveBlockedUserList()
             
             } else {

--- a/GitSpace/Sources/ViewModels/UserViewModel.swift
+++ b/GitSpace/Sources/ViewModels/UserViewModel.swift
@@ -25,16 +25,9 @@ final class UserStore: ObservableObject {
     @Published var users: [UserInfo]
     
     init(
-		users: [UserInfo] = [],
-		currentUserID: String
+		users: [UserInfo] = []
 	) {
         self.users = users
-//		Task {
-//			let currentUser = await self.requestUserInfoWithID(userID: currentUserID)
-//			if let currentUser {
-//				await assignCurrentUser(with: currentUser)
-//			}
-//		}
     }
     
     private func getUserDocument(userID: String) async -> DocumentSnapshot? {

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomView.swift
@@ -444,7 +444,7 @@ struct ChatRoomView: View, Blockable {
         /// 4. user의 차단 유저 리스트에 채팅 대화 상대방 ID가 있는지 여부 검사
         /// 5. 1~4에서 받아온 정보를 통해서 채팅방 상세 설정 뷰로 이동
         // 1
-        if let user = userStore.user {
+        if let user = userStore.currentUser {
             let chatRoomNotificationKey = Constant.AppStorageConst.CHATROOM_NOTIFICATION
             let isNotificationReceiveEnableDict = UserDefaults().dictionary(forKey: chatRoomNotificationKey)
             // 2


### PR DESCRIPTION
## 개요 및 관련 이슈
- 동일한 용도임에도 두 가지 프로퍼티로 사용되고 있었던 user와 currentUser를 currentUser로 통합했습니다.
- #427

## 작업 사항
- user 프로퍼티 삭제
- 기존 user 사용 코드를 currentUser로 변경
- InitialView 내부에서 별도로 초기화했던 UserStore를 App에서 다른 environmentObject와 같이 전달하도록 변경
- UserViewModel 내부의 함수 코드를 연관성 있는 순서대로 재배치
- 기록용으로 주석처리된 로직을 스코프 최하단으로 이동
