### PR TITLE
Feat/#443 knock contents encryption

### DIFF
--- a/GitSpace/Sources/Views/Knock/MainKnockBox/EachKnockCell.swift
+++ b/GitSpace/Sources/Views/Knock/MainKnockBox/EachKnockCell.swift
@@ -90,7 +90,8 @@ struct EachKnockCell: View {
                     .id(eachKnock.id)
                     
                     HStack {
-                        Text(eachKnock.knockMessage)
+                        // !!!: base String을 decode
+                        Text(eachKnock.knockMessage.decodedBase64String ?? "복호화")
                             .lineLimit(1)
                         
                         Spacer()

--- a/GitSpace/Sources/Views/Knock/MainKnockBox/KnockHistoryView.swift
+++ b/GitSpace/Sources/Views/Knock/MainKnockBox/KnockHistoryView.swift
@@ -74,7 +74,7 @@ struct KnockHistoryView: View {
                     TextEditor(text: $editedKnockMessage)
                         .autocorrectionDisabled()
                         .textInputAutocapitalization(.never)
-                        .foregroundColor(.black)
+                        .foregroundColor(.primary)
                         .frame(
                             maxWidth: UIScreen.main.bounds.width / 1.2,
                             minHeight: 100
@@ -92,7 +92,7 @@ struct KnockHistoryView: View {
                             withAnimation {
                                 endTextEditing()
                                 isEditingKnockMessage.toggle()
-                                editedKnockMessage = eachKnock.knockMessage
+                                editedKnockMessage = eachKnock.knockMessage.decodedBase64String ?? "복호화"
                             }
                         } label: {
                             Text("Cancel")
@@ -144,7 +144,7 @@ struct KnockHistoryView: View {
             } else {
                 VStack(alignment: .leading) {
                     HStack {
-                        Text("\(eachKnock.knockMessage)")
+                        Text("\(eachKnock.knockMessage.decodedBase64String ?? "복호화")")
                             .font(.callout)
                             .foregroundColor(Color.black)
                     }
@@ -342,7 +342,7 @@ struct KnockHistoryView: View {
     }
     
     private func assignKnockMessageIntoEditState() {
-        editedKnockMessage = eachKnock.knockMessage
+        editedKnockMessage = eachKnock.knockMessage.decodedBase64String ?? "복호화"
     }
     
     private func assignChatWithChatID() async {

--- a/GitSpace/Sources/Views/Knock/MainKnockBox/ReceivedKnockDetailView.swift
+++ b/GitSpace/Sources/Views/Knock/MainKnockBox/ReceivedKnockDetailView.swift
@@ -270,8 +270,8 @@ struct ReceivedKnockDetailView: View {
             ],
             lastContent: "",
             lastContentDate: .now,
-            // !!!: baseString
-            knockContent: knock.knockMessage,
+            // !!!: Decoded
+            knockContent: knock.knockMessage.decodedBase64String ?? "",
             knockContentDate: knock.knockedDate.dateValue(),
             unreadMessageCount: [
                 userStore.currentUser?.id ?? "": 0,
@@ -287,8 +287,8 @@ struct ReceivedKnockDetailView: View {
             joinedMemberIDs: [knock.sentUserID, knock.receivedUserID],
             lastContent: "",
             lastContentDate: .now,
-            // !!!: baseString
-            knockContent: knock.knockMessage,
+            // !!!: Decoded
+            knockContent: knock.knockMessage.decodedBase64String ?? "",
             knockContentDate: knock.knockedDate.dateValue(),
             unreadMessageCount: [knock.sentUserID : 0, knock.receivedUserID : 0]
         )

--- a/GitSpace/Sources/Views/Knock/MainKnockBox/ReceivedKnockDetailView.swift
+++ b/GitSpace/Sources/Views/Knock/MainKnockBox/ReceivedKnockDetailView.swift
@@ -97,6 +97,7 @@ struct ReceivedKnockDetailView: View {
                     /// 3. 메세지 내용
                     VStack(alignment: .leading) {
                         HStack {
+                            // !!!: base String decode
                             Text("\(knock.knockMessage)")
                                 .font(.callout)
                                 .foregroundColor(Color.black)
@@ -269,6 +270,7 @@ struct ReceivedKnockDetailView: View {
             ],
             lastContent: "",
             lastContentDate: .now,
+            // !!!: baseString
             knockContent: knock.knockMessage,
             knockContentDate: knock.knockedDate.dateValue(),
             unreadMessageCount: [
@@ -278,15 +280,18 @@ struct ReceivedKnockDetailView: View {
         )
     }
     
-    private func makeNewChat() -> Chat {
-        return Chat.init(id: UUID().uuidString,
-                         createdDate: .now,
-                         joinedMemberIDs: [knock.sentUserID, knock.receivedUserID],
-                         lastContent: "",
-                         lastContentDate: .now,
-                         knockContent: knock.knockMessage,
-                         knockContentDate: knock.knockedDate.dateValue(),
-                         unreadMessageCount: [knock.sentUserID : 0, knock.receivedUserID : 0])
+    private func makeNewChat() -> Chat  {
+        return Chat.init(
+            id: UUID().uuidString,
+            createdDate: .now,
+            joinedMemberIDs: [knock.sentUserID, knock.receivedUserID],
+            lastContent: "",
+            lastContentDate: .now,
+            // !!!: baseString
+            knockContent: knock.knockMessage,
+            knockContentDate: knock.knockedDate.dateValue(),
+            unreadMessageCount: [knock.sentUserID : 0, knock.receivedUserID : 0]
+        )
     }
 }
 //

--- a/GitSpace/Sources/Views/Knock/SendKnock/AfterSendKnockSection.swift
+++ b/GitSpace/Sources/Views/Knock/SendKnock/AfterSendKnockSection.swift
@@ -44,19 +44,22 @@ struct AfterSendKnockSection: View {
             }
             .padding(.leading, 20)
             
-            GSCanvas.CustomCanvasView.init(
+            GSCanvas.CustomCanvasView(
                 style: .primary,
                 content: {
                     HStack {
                         Spacer()
                         GSText.CustomTextView(
                             style: .captionPrimary1,
-                            string: "\(knockViewManager.newKnock?.knockMessage ?? "")")
+                            string: "\(knockViewManager.newKnock?.knockMessage.decodedBase64String ?? "")")
                         Spacer()
                     }
                 })
             .padding(.horizontal, 20)
             .padding(.vertical, 5)
+            .onAppear {
+                print("DECODED?", knockViewManager.newKnock?.knockMessage.decodedBase64String)
+            }
         }
     }
 }

--- a/GitSpace/Sources/Views/Knock/SendKnock/SendKnockTextEditSection.swift
+++ b/GitSpace/Sources/Views/Knock/SendKnock/SendKnockTextEditSection.swift
@@ -78,7 +78,6 @@ struct SendKnockTextEditSection: View {
                             // Assign New Knock On Model
                             knockViewManager.assignNewKnock(newKnock: newKnock)
                             
-                            // TODO: 알람 보내기
                             // 새로운 노크가 생성될 때의 Push Notification 전달
                             await pushNotificationManager.sendNotification(
                                 with: .knock(

--- a/GitSpace/Sources/Views/Knock/SendKnock/SendKnockView.swift
+++ b/GitSpace/Sources/Views/Knock/SendKnock/SendKnockView.swift
@@ -39,7 +39,7 @@ struct SendKnockView: View {
             if let targetUserInfo {
                 ScrollViewReader { proxy in
                     ScrollView {
-                        HStack {}.id(topID)
+                        HStack { }.id(topID)
                         VStack(alignment: .center, spacing: 10) {
                             TopperProfileView(
                                 targetUserInfo: targetUserInfo
@@ -101,8 +101,7 @@ struct SendKnockView: View {
                             
                         }
                         
-                        HStack {
-                        }
+                        HStack { }
                         .id(bottomID)
                         .frame(height: isKnockSent ? 5 : 280)
                     }


### PR DESCRIPTION
## 개요 및 관련 이슈
- Knock content 에 해당하는 암호화를 적용합니다.
- Create와 Update 시점에 Encode 합니다.
- Read가 아니라 `View` 내부에서만 Decode 합니다.
    - 🤔 이유: 로직 관리 용이성
    - 속성의 의존성은 모두 Encoding된 데이터로 전달하고 View에서만 Decode하도록 하여 단순성 확보

## 작업 사항
- 간단한 Indent 수정
- Create, Update 시점의 데이터를 `.asBase64`로 mutate
- 기존 TextEditor가 갖고 있던 배경화면 `.black` -> `.primary` 로 수정

- 작업 내용이 적어서 로직은 생략합니다!