### PR TITLE
[Feat] Chat / Message에 Base64 암호화를 적용했습니다.

### DIFF
--- a/GitSpace/Sources/Models/Chat.swift
+++ b/GitSpace/Sources/Models/Chat.swift
@@ -16,7 +16,7 @@ struct Chat: Identifiable, Codable {
     let joinedMemberIDs: [String] // 채팅방에 참여한 유저 ID 리스트
     var lastContent: String // 마지막 메세지 내용
     var lastContentDate: Date // 마지막 메세지 날짜
-    let knockContent: String // 노크 메세지 내용
+    var knockContent: String // 노크 메세지 내용
     let knockContentDate: Date // 노크 메세지 날짜
     var unreadMessageCount: [String : Int] // 읽지 않은 메시지 갯수 (userID : 읽지 않은 메시지 갯수)
     
@@ -74,5 +74,19 @@ struct Chat: Identifiable, Codable {
             knockContentDate: .now,
             unreadMessageCount: [:]
         )
+    }
+    
+    static func encodedChat(with chat: Chat) -> Chat {
+        var encodedChat: Chat = chat
+        encodedChat.knockContent = chat.knockContent.asBase64 ?? ""
+        encodedChat.lastContent = chat.lastContent.asBase64 ?? ""
+        return encodedChat
+    }
+    
+    static func decodedChat(with chat: Chat) -> Chat {
+        var decodedChat: Chat = chat
+        decodedChat.knockContent = chat.knockContent.decodedBase64String ?? ""
+        decodedChat.lastContent = chat.lastContent.decodedBase64String ?? ""
+        return decodedChat
     }
 }

--- a/GitSpace/Sources/Models/Message.swift
+++ b/GitSpace/Sources/Models/Message.swift
@@ -1,5 +1,5 @@
 //
-//  ChatCellModel.swift
+//  MessageCellModel.swift
 //  GitSpace
 //
 //  Created by 원태영 on 2023/01/27.
@@ -11,7 +11,7 @@ import Foundation
 struct Message : Identifiable, Codable {
     let id: String // 메세지 ID
     let senderID: String // 메세지 작성자 유저 ID
-    let textContent: String // 메세지 내용
+    var textContent: String // 메세지 내용
     let imageContent: String? // 메세지에 첨부한 이미지
     let sentDate: Date // 메세지 작성 날짜
     let isRead: Bool // 수신 유저의 메세지 확인 여부
@@ -23,5 +23,17 @@ struct Message : Identifiable, Codable {
         dateFormatter.dateFormat = "HH:mm"
         
         return dateFormatter.string(from: sentDate)
+    }
+    
+    static func encodedMessage(with message: Message) -> Message {
+        var encodedMessage: Message = message
+        encodedMessage.textContent = message.textContent.asBase64 ?? ""
+        return encodedMessage
+    }
+    
+    static func decodedMessage(with message: Message) -> Message {
+        var decodedMessage: Message = message
+        decodedMessage.textContent = message.textContent.decodedBase64String ?? ""
+        return decodedMessage
     }
 }

--- a/GitSpace/Sources/ViewModels/MessageViewModel.swift
+++ b/GitSpace/Sources/ViewModels/MessageViewModel.swift
@@ -84,7 +84,8 @@ extension MessageStore {
             for document in snapshot.documents {
                 do {
                     let message: Message = try document.data(as: Message.self)
-                    newMessages.append(message)
+                    let decodedMessage: Message = .decodedMessage(with: message)
+                    newMessages.append(decodedMessage)
                 } catch {
                     print("Error-\(#file)-\(#function) : \(error.localizedDescription)")
                 }
@@ -95,19 +96,21 @@ extension MessageStore {
     
     // MARK: - Message CRUD
     func addMessage(_ message: Message, chatID: String) {
+        let encodedMessage: Message = .encodedMessage(with: message)
         do {
             try db
                 .collection(const.COLLECTION_CHAT)
                 .document(chatID)
                 .collection(const.COLLECTION_MESSAGE)
                 .document(message.id)
-                .setData(from: message.self)
+                .setData(from: encodedMessage.self)
         } catch {
             print("Error-\(#file)-\(#function) : \(error.localizedDescription)")
         }
     }
     
     func updateMessage(_ message: Message, chatID: String) async {
+        let encodedMessage: Message = .encodedMessage(with: message)
         do {
             try await db
                 .collection(const.COLLECTION_CHAT)
@@ -115,8 +118,8 @@ extension MessageStore {
                 .collection(const.COLLECTION_MESSAGE)
                 .document(message.id)
                 .updateData(
-                    [const.FIELD_TEXT_CONTENT : message.textContent,
-                     const.FIELD_SENT_DATE : message.sentDate])
+                    [const.FIELD_TEXT_CONTENT : encodedMessage.textContent,
+                     const.FIELD_SENT_DATE : encodedMessage.sentDate])
         } catch {
             print("Error-\(#file)-\(#function) : \(error.localizedDescription)")
         }
@@ -143,7 +146,8 @@ extension MessageStore {
     func fetchNewMessage(change : QueryDocumentSnapshot) -> Message? {
         do {
             let newMessage = try change.data(as: Message.self)
-            return newMessage
+            let decodedNewMessage: Message = .decodedMessage(with: newMessage)
+            return decodedNewMessage
         } catch {
             print("Error-\(#file)-\(#function) : \(error.localizedDescription)")
         }

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomKnockSection.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomKnockSection.swift
@@ -14,7 +14,8 @@ struct ChatDetailKnockSection: View {
     
     var body: some View {
         VStack(spacing: 10) {
-            GSText.CustomTextView(style: .sectionTitle, string: chat.knockContentDateAsString)
+            GSText.CustomTextView(style: .sectionTitle,
+                                  string: chat.knockContentDateAsString)
                 .padding(.bottom, 10)
             
             HStack {

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomKnockSection.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomKnockSection.swift
@@ -37,9 +37,9 @@ struct ChatDetailKnockSection: View {
             
             GSCanvas.CustomCanvasView(style: .primary) {
                 HStack {
-                    Spacer()
-                    GSText.CustomTextView(style: .body1, string: chat.knockContent)
-                    Spacer()
+                    GSText.CustomTextView(style: .body1,
+                                          string: chat.knockContent)
+                    .frame(maxWidth: .infinity)
                 }
             }
             .padding(.horizontal, 20)

--- a/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomKnockSection.swift
+++ b/GitSpace/Sources/Views/Chat/ChatRoom/ChatRoomKnockSection.swift
@@ -42,10 +42,6 @@ struct ChatDetailKnockSection: View {
                 }
             }
             .padding(.horizontal, 20)
-            
-//            Text(chat.knockContent)
-//                .modifier(KnockMessageModifier())
-           
         }
     }
 }


### PR DESCRIPTION
## 개요 및 관련 이슈
- #442 
- #447 
- 사용자의 개인정보 및 사생활 보호를 위해 Chat, Message 등 채팅 기능 사용 전반에서 생성되는 텍스트 컨텐츠에 대한 암호화를 적용했습니다.

## 작업 사항
- Chat과 Message 객체에 인코딩 / 디코딩 처리된 객체 생성 메서드 추가
- Request, Add, Update 등 CRUD 시점에 인코딩 or 디코딩 처리 로직 추가

### `Encoded/Decoded Chat/Message`
- 기존 객체를 받아서 인코딩 / 디코딩 처리된 객체를 반환하는 메서드를 추가했습니다.
- 기존 Request, Add 로직에서 Data 자체를 아규먼트로 전달하는 로직을 그대로 유지하기 위해 구현되었습니다.

```swift
static func encodedChat(with chat: Chat) -> Chat {
    var encodedChat: Chat = chat
    encodedChat.knockContent = chat.knockContent.asBase64 ?? ""
    encodedChat.lastContent = chat.lastContent.asBase64 ?? ""
    return encodedChat
}

static func decodedChat(with chat: Chat) -> Chat {
    var decodedChat: Chat = chat
    decodedChat.knockContent = chat.knockContent.decodedBase64String ?? ""
    decodedChat.lastContent = chat.lastContent.decodedBase64String ?? ""
    return decodedChat
}

static func encodedMessage(with message: Message) -> Message {
    var encodedMessage: Message = message
    encodedMessage.textContent = message.textContent.asBase64 ?? ""
    return encodedMessage
}

static func decodedMessage(with message: Message) -> Message {
    var decodedMessage: Message = message
    decodedMessage.textContent = message.textContent.decodedBase64String ?? ""
    return decodedMessage
}
```

### `CRUD 시점에 인코딩 / 디코딩`
- 서버에 올리기 전에 인코딩, UI에 표시할 데이터를 추가하기 전에 디코딩 하는 방식으로 처리했습니다.
- Chat과 Message CRUD 전반에 적용되었고, 형태는 아래 예시 코드와 같습니다.

```diff

func fetchMessages(chatID: String, unreadMessageCount: Int) async {
    
    let snapshot = await getMessageDocuments(chatID, unreadMessageCount: unreadMessageCount)
    var newMessages: [Message] = []
    
    if let snapshot {
        for document in snapshot.documents {
            do {
                let message: Message = try document.data(as: Message.self)
+                let decodedMessage: Message = .decodedMessage(with: message)
                newMessages.append(decodedMessage)
            } catch {
                print("Error-\(#file)-\(#function) : \(error.localizedDescription)")
            }
        }
    }
    await writeMessages(messages: newMessages)
}

func addMessage(_ message: Message, chatID: String) {
+    let encodedMessage: Message = .encodedMessage(with: message)
    do {
        try db
            .collection(const.COLLECTION_CHAT)
            .document(chatID)
            .collection(const.COLLECTION_MESSAGE)
            .document(message.id)
            .setData(from: encodedMessage.self)
    } catch {
        print("Error-\(#file)-\(#function) : \(error.localizedDescription)")
    }
}

```

## 논의 필요 사항
- Chat 객체에 Knock 메세지가 포함되어있고, Chat의 생성 로직이 KnockView에 포함되어 있어서 인코딩 로직에 대한 논의가 필요합니다! 
(현재는 Chat에 암호화되지 않은 KnockMessage가 전달되는 것을 가정하고 구현되어있습니다.)