### PR TITLE
[Feat] 앱 버전 체크 및 강제 업데이트 로직을 구현했습니다.

### DIFF
--- a/GitSpace.xcodeproj/project.pbxproj
+++ b/GitSpace.xcodeproj/project.pbxproj
@@ -115,6 +115,8 @@
 		6E000CAF29899F6C00446C0D /* ChatModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E000CAE29899F6C00446C0D /* ChatModifiers.swift */; };
 		6E000CB32989A2F700446C0D /* ChatRoomKnockSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E000CB22989A2F700446C0D /* ChatRoomKnockSection.swift */; };
 		6E000CB7298A67E800446C0D /* GithubProfileImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E000CB6298A67E800446C0D /* GithubProfileImage.swift */; };
+		6E03AFD02A52704E0076DC02 /* AppStoreUpdateChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E03AFCF2A52704E0076DC02 /* AppStoreUpdateChecker.swift */; };
+		6E03AFD22A5278500076DC02 /* AppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E03AFD12A5278500076DC02 /* AppInfo.swift */; };
 		6E0840152983902800F51169 /* Chat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E0840142983902800F51169 /* Chat.swift */; };
 		6E0840192983948300F51169 /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E0840182983948300F51169 /* ChatViewModel.swift */; };
 		6E08401B298394DF00F51169 /* MessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E08401A298394DF00F51169 /* MessageViewModel.swift */; };
@@ -300,6 +302,8 @@
 		6E000CAE29899F6C00446C0D /* ChatModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatModifiers.swift; sourceTree = "<group>"; };
 		6E000CB22989A2F700446C0D /* ChatRoomKnockSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRoomKnockSection.swift; sourceTree = "<group>"; };
 		6E000CB6298A67E800446C0D /* GithubProfileImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GithubProfileImage.swift; sourceTree = "<group>"; };
+		6E03AFCF2A52704E0076DC02 /* AppStoreUpdateChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreUpdateChecker.swift; sourceTree = "<group>"; };
+		6E03AFD12A5278500076DC02 /* AppInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfo.swift; sourceTree = "<group>"; };
 		6E0840142983902800F51169 /* Chat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Chat.swift; sourceTree = "<group>"; };
 		6E0840162983906F00F51169 /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		6E0840182983948300F51169 /* ChatViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.swift; sourceTree = "<group>"; };
@@ -425,6 +429,7 @@
 				2205F23E299CC04400B2643D /* FollowerResponse.swift */,
 				34BF6A6729C9F04700D15DFE /* FollowingResponse.swift */,
 				2205F23C299C9F1400B2643D /* Event.swift */,
+				6E03AFD12A5278500076DC02 /* AppInfo.swift */,
 			);
 			path = APIModels;
 			sourceTree = "<group>";
@@ -433,6 +438,7 @@
 			isa = PBXGroup;
 			children = (
 				225A22CE299778A900786B35 /* GitHubService.swift */,
+				6E03AFCF2A52704E0076DC02 /* AppStoreUpdateChecker.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1031,6 +1037,7 @@
 				0BDBDD3529B9E7F000F0D3FD /* LottieView.swift in Sources */,
 				70DB32B42989FAB0004E82AD /* SetMainView.swift in Sources */,
 				7EB99A4129EC410D00863341 /* Report.swift in Sources */,
+				6E03AFD02A52704E0076DC02 /* AppStoreUpdateChecker.swift in Sources */,
 				7EB99A3D29EC2E8900863341 /* Blockable.swift in Sources */,
 				22390DF329B84EBD00A0D49D /* RepositoryDetailViewModel.swift in Sources */,
 				700A11D6299771B5008C94C7 /* KnockViewManager.swift in Sources */,
@@ -1134,6 +1141,7 @@
 				6E0840212983979B00F51169 /* MessageCell.swift in Sources */,
 				6E000CB32989A2F700446C0D /* ChatRoomKnockSection.swift in Sources */,
 				EE0CC79B2976F2160096A873 /* ContributorListView.swift in Sources */,
+				6E03AFD22A5278500076DC02 /* AppInfo.swift in Sources */,
 				7068B6C22976952B005D6B7B /* MainProfileView.swift in Sources */,
 				347146052991F02500ED990C /* GuideCenterView.swift in Sources */,
 				6E70333C29890AD000FFC018 /* ChatUserRecommendationSection.swift in Sources */,

--- a/GitSpace/InitialView.swift
+++ b/GitSpace/InitialView.swift
@@ -61,8 +61,20 @@ struct InitialView: View {
             }
         )
         .onViewDidLoad {
-            if githubAuthManager.authentification.currentUser != nil && UserDefaults.standard.string(forKey: "AT") != nil {
-                Task {
+            Task {
+                let newVersionCheckResult = await AppStoreUpdateChecker.isNewVersionAvailable()
+                
+                switch newVersionCheckResult {
+                case .success(let isNewVersionAvailable):
+                    showingForceUpdateAlert = isNewVersionAvailable
+                    
+                case .failure(let error):
+                    print(error.localizedDescription)
+                }
+                
+                if githubAuthManager.authentification.currentUser != nil
+                    && UserDefaults.standard.string(forKey: "AT") != nil
+                    && showingForceUpdateAlert == false {
                     await githubAuthManager.reauthenticateUser()
                     githubAuthManager.state = .signedIn
                 }

--- a/GitSpace/InitialView.swift
+++ b/GitSpace/InitialView.swift
@@ -12,6 +12,7 @@ struct InitialView: View {
     @EnvironmentObject var githubAuthManager: GitHubAuthManager
     @EnvironmentObject var pushNotificationManager: PushNotificationManager
     let tabBarRouter: GSTabBarRouter
+    @State private var showingForceUpdateAlert: Bool = false
     
     // MARK: - 한호
     @AppStorage("systemAppearance") private var systemAppearance: Int = AppearanceType.allCases.first!.rawValue
@@ -43,6 +44,22 @@ struct InitialView: View {
                     .preferredColorScheme(selectedAppearance)
             }
         }
+        .alert(
+            "Notice: App Update",
+            isPresented: $showingForceUpdateAlert,
+            actions: {
+                Button {
+                    UIApplication.shared.open(URL(string: "https://apps.apple.com/kr/app/gitspace/id6446034470")!)
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                        exit(0)
+                    }
+                } label: {
+                    Text("OK")
+                }
+            }, message: {
+                Text("The latest version has been released. Please update it.")
+            }
+        )
         .onViewDidLoad {
             if githubAuthManager.authentification.currentUser != nil && UserDefaults.standard.string(forKey: "AT") != nil {
                 Task {

--- a/GitSpace/InitialView.swift
+++ b/GitSpace/InitialView.swift
@@ -54,10 +54,10 @@ struct InitialView: View {
                         exit(0)
                     }
                 } label: {
-                    Text("OK")
+                    Text("Update")
                 }
             }, message: {
-                Text("The latest version has been released. Please update it.")
+                Text("There is a new version available. Please update your app.")
             }
         )
         .onViewDidLoad {

--- a/GitSpace/Sources/Network/APIModels/AppInfo.swift
+++ b/GitSpace/Sources/Network/APIModels/AppInfo.swift
@@ -1,0 +1,17 @@
+//
+//  AppInfo.swift
+//  GitSpace
+//
+//  Created by 원태영 on 2023/07/03.
+//
+
+import Foundation
+
+struct AppInfo: Codable {
+    let resultCount: Int
+    let results: [AppInfoResult]
+}
+
+struct AppInfoResult: Codable {
+    let version: String
+}

--- a/GitSpace/Sources/Network/Services/AppStoreUpdateChecker.swift
+++ b/GitSpace/Sources/Network/Services/AppStoreUpdateChecker.swift
@@ -1,0 +1,13 @@
+//
+//  AppStoreUpdateChecker.swift
+//  GitSpace
+//
+//  Created by 원태영 on 2023/07/03.
+//
+
+import Foundation
+
+final class AppStoreUpdateChecker {
+    
+    
+}

--- a/GitSpace/Sources/Network/Services/AppStoreUpdateChecker.swift
+++ b/GitSpace/Sources/Network/Services/AppStoreUpdateChecker.swift
@@ -21,5 +21,54 @@ enum AppStoreUpdateCheckerError: Error {
 
 final class AppStoreUpdateChecker {
     
+    static func isNewVersionAvailable() async -> Result<Bool, AppStoreUpdateCheckerError> {
+        guard let infoDictionary = Bundle.main.infoDictionary else {
+            return .failure(.invalidInfoDictionary)
+        }
+        
+        guard let bundleID = Bundle.main.bundleIdentifier else {
+            return .failure(.invalidBundleID)
+        }
+        
+        guard var currentVersionNumber = infoDictionary["CFBundleShortVersionString"] as? String else {
+            return .failure(.invalidCurrentVersionNumber)
+        }
+        
+        if currentVersionNumber.components(separatedBy: ".").count <= 2 {
+            currentVersionNumber += ".0"
+        }
+        
+        guard let url = URL(string: "http://itunes.apple.com/lookup?bundleId=\(bundleID)") else {
+            return .failure(.invalidItunesURL)
+        }
+        
+        do {
+            let (data, urlResponse) = try await URLSession.shared.data(from: url)
+
+            guard let response = urlResponse as? HTTPURLResponse else {
+                return .failure(.invalidResponse)
+            }
+            
+            guard Array(200...299).contains(response.statusCode) else {
+                return .failure(.unexpectedStatusCode)
+            }
+
+            guard let decodedResponse = try? JSONDecoder().decode(
+                AppInfo.self,
+                from: data
+            ) else {
+                return .failure(.failToDecoding)
+            }
+            
+            guard let latestVersionNumber = decodedResponse.results.first?.version else {
+                return .failure(.emptyResponse)
+            }
+            
+            return .success(currentVersionNumber != latestVersionNumber)
+
+        } catch {
+            return .failure(.unknown)
+        }
+    }
     
 }

--- a/GitSpace/Sources/Network/Services/AppStoreUpdateChecker.swift
+++ b/GitSpace/Sources/Network/Services/AppStoreUpdateChecker.swift
@@ -21,23 +21,40 @@ enum AppStoreUpdateCheckerError: Error {
 
 final class AppStoreUpdateChecker {
     
+    /**
+     클라이언트 앱 버전과 App Store의 릴리즈 앱 버전을 비교해서 업데이트 가능 여부를 반환하는 함수입니다.
+     
+     - Author: 태영, 다혜
+     
+     - Since: 2023.07.03
+     
+     - Returns: 현재 버전과 릴리즈 버전이 동일한지를 반환합니다.
+     */
     static func isNewVersionAvailable() async -> Result<Bool, AppStoreUpdateCheckerError> {
+        // 앱 번들 인포 리스트 딕셔너리
         guard let infoDictionary = Bundle.main.infoDictionary else {
             return .failure(.invalidInfoDictionary)
         }
         
+        // 앱 번들 ID
         guard let bundleID = Bundle.main.bundleIdentifier else {
             return .failure(.invalidBundleID)
         }
         
+        /// 앱 버전
+        /// ex) 1.0.0
         guard var currentVersionNumber = infoDictionary["CFBundleShortVersionString"] as? String else {
             return .failure(.invalidCurrentVersionNumber)
         }
         
+        /// 클라이언트에서 제공하는 앱 버전은 마지막 숫자가 0이면 스킵하여 제공함
+        /// API에서 제공받은 버전과 비교하기 위해 스킵된 경우 동일한 형식으로 맞추기 위해 .0을 뒤에 추가
+        /// ex) 1.0.0 -> 1.0
         if currentVersionNumber.components(separatedBy: ".").count <= 2 {
             currentVersionNumber += ".0"
         }
         
+        // ItunesAPI 요청 URL
         guard let url = URL(string: "http://itunes.apple.com/lookup?bundleId=\(bundleID)") else {
             return .failure(.invalidItunesURL)
         }

--- a/GitSpace/Sources/Network/Services/AppStoreUpdateChecker.swift
+++ b/GitSpace/Sources/Network/Services/AppStoreUpdateChecker.swift
@@ -7,6 +7,18 @@
 
 import Foundation
 
+enum AppStoreUpdateCheckerError: Error {
+    case invalidInfoDictionary
+    case invalidBundleID
+    case invalidCurrentVersionNumber
+    case invalidItunesURL
+    case invalidResponse
+    case failToDecoding
+    case unexpectedStatusCode
+    case unknown
+    case emptyResponse
+}
+
 final class AppStoreUpdateChecker {
     
     

--- a/GitSpace/Sources/Network/Services/AppStoreUpdateChecker.swift
+++ b/GitSpace/Sources/Network/Services/AppStoreUpdateChecker.swift
@@ -48,8 +48,8 @@ final class AppStoreUpdateChecker {
         }
         
         /// 클라이언트에서 제공하는 앱 버전은 마지막 숫자가 0이면 스킵하여 제공함
-        /// API에서 제공받은 버전과 비교하기 위해 스킵된 경우 동일한 형식으로 맞추기 위해 .0을 뒤에 추가
         /// ex) 1.0.0 -> 1.0
+        /// API에서 제공받은 버전과 비교하기 위해 스킵된 경우 동일한 형식으로 맞추기 위해 .0을 뒤에 추가
         if currentVersionNumber.components(separatedBy: ".").count <= 2 {
             currentVersionNumber += ".0"
         }


### PR DESCRIPTION
## 개요 및 관련 이슈
- #451 

<br>

## ⚒️ 작업 사항
- iTunes API Response를 담을 AppInfo 객체를 추가했습니다.
- 앱 버전 체크 기능을 담당하는 AppStoreUpdateChecker 클래스를 추가했습니다.
- 클라이언트 버전과 릴리즈 버전을 비교하는 isNewVersionAvailable 메서드를 추가했습니다.
- App 시작 시점에 버전을 체크해서 강제 업데이트를 유도하는 로직을 추가했습니다.

### `AppInfo`
- AppInfo 모델은 iTunes API의 lookup 정보에 대한 Reponse 타입입니다.
```swift
struct AppInfo: Codable {
    let resultCount: Int
    let results: [AppInfoResult]
}

struct AppInfoResult: Codable {
    let version: String
}
```

### `AppStoreUpdateChecker`
- AppStoreUpdateChecker 클래스는 iTunes API 통신, 앱 번들 버전과 릴리즈 버전의 비교 기능 담당합니다.

```swift
enum AppStoreUpdateCheckerError: Error {
    case invalidInfoDictionary
    case invalidBundleID
    case invalidCurrentVersionNumber
    case invalidItunesURL
    case invalidResponse
    case failToDecoding
    case unexpectedStatusCode
    case unknown
    case emptyResponse
}

final class AppStoreUpdateChecker {

    static func isNewVersionAvailable() async -> Result<Bool, AppStoreUpdateCheckerError> {
        ...
    }
}
```

### `강제 업데이트 로직`
- 위에서 구현한 로직을 통해 현재 클라이언트의 앱 번들 버전이 AppStore에 릴리즈 되어있는 버전과 동일한지를 파악합니다.
- 만약 같지 않다면, 업데이트 안내 Alert을 표시하고 `Update` 버튼을 탭하면 AppStore로 리다이렉팅합니다.
- 버전이 같다면 기존과 같이 자동 로그인 검사 후 결과에 맞게 처리합니다.
- AppStore로 리다이렉팅 된 후, 유저가 직접 앱으로 돌아오면 수동 로그인 로직을 수행할 수 있기 때문에 앱을 강제로 종료하는 로직을 추가했습니다.

```swift
.alert(
    ...
    isPresented: $showingForceUpdateAlert,
    actions: {
        Button {
            UIApplication.shared.open(URL(string: "https://apps.apple.com/kr/app/gitspace/id6446034470")!)
            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                exit(0)
            }
        } label: {
            Text("Update")
        }
    }
    ...
)
.onViewDidLoad {
    Task {
        let newVersionCheckResult = await AppStoreUpdateChecker.isNewVersionAvailable()
        
        switch newVersionCheckResult {
        case .success(let isNewVersionAvailable):
            showingForceUpdateAlert = isNewVersionAvailable
            
        case .failure(let error):
            print(error.localizedDescription)
        }
       ...
    }
}
```

<br>

## 🚀 작업 결과
| ![giphy](https://github.com/APPSCHOOL1-REPO/finalproject-gitspace/assets/45925685/4c7f418c-5522-4a7d-a605-a86e0ca99f14) |
|:--:|


<br>

## 📋 메모

### 알게된 사실
- **앱 강제 종료**는 일반적으로 애플에서 권장하는 사항은 아니다. 사용자에게 앱을 종료하도록 하는 메세지나 UI를 표시하여 사용자가 선택할 수 있게 하거나, 필요한 동작을 수행하고 난 후 앱이 종료되도록 하는게 좋다. 또한, 앱이 Fatal Error처럼 즉시 종료되는 현상은 리젝 사유가 될 수 있기 때문에, 종료에 대한 애니메이션 효과나 다른 화면으로 이동하면서 자연스럽게 종료되도록 해야 리젝을 방지할 수 있다.
- `exit()` 메서드를 통해 앱을 강제 종료할 수 있다. 아규먼트로 Int 값을 전달할 수 있는데, 종료 예약시간처럼 보이지만 종료의 성공적 여부 (0: 성공, 1: 실패)를 의미한다. 하지만 다른 숫자 (2, -1, 10) 등을 전달해도 종료 자체는 잘 수행된다.
- **현재 앱의 버전**(**Bundle.main.-**)의 3번째 숫자가 0일 경우(ex. 1.0.0), 마지막 3번째 숫자가 생략될 수 있다. 그래서 최신 버전과 비교할 때 3번째 숫자가 없어서 같은 버전임에도 다르다고 할 수도 있다. (ex. 1.0 != 1.0.0)

### 작업 요약
- **initialView**의 onViewDidLoad 수정자에서 **(1)앱 버전을 체크**하고, **(2)결과에 따라 버전 업데이트 Alert 혹은 자동 로그인**을 실행하도록 구현했다.
- **AppInfo** 모델은 iTunes API의 lookup 정보에 대한 response 타입이다. 현재 해당 response에서 'version' 필드만 사용하고 있다.
- **시뮬레이터에서는 앱스토어 주소로 이동이 안된다.** Alert에서 'Update' 버튼을 누르면 앱 업데이트를 위해 앱스토어 주소를 열도록 설정해두었는데, 실기기에서만 정상적으로 이동이 되는 것을 확인하였다.
- **앱 업데이트 Alert의 'Update' 버튼을 누르면 앱스토어로 이동**한다. 이때, GitSpace 앱은 'Update' 버튼을 누르고 0.5초 뒤 exit() 되어서 앱이 자연스럽게 종료된다.

### 얘기해봐야할 내용
- 규니의 **네트워크 코드**는 현재 GitHub API에 맞게 구현되어 있어서 다른 API 코드와 함께 사용하기 위해서는 약간의 수정이 필요하다. 규니와 논의 필요!
- **앱 업데이트 Alert의 설명 문구에 대한 논의**가 필요하다. 일단 임시로 쉬운 말로 작성해두었다. 팀원들과 문구를 같이 확인하고, 유지할지 수정할지 결정하자.